### PR TITLE
Phase 2: Parser (構文解析)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod lexer;
+pub mod parser;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,0 +1,128 @@
+use crate::lexer::token::Span;
+
+/// 型
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Type {
+    U8,
+    Bool,
+    Unit,
+    Array(Box<Type>, usize),
+    Sprite(usize),
+}
+
+/// 二項演算子
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Eq,
+    NotEq,
+    Lt,
+    Gt,
+    LtEq,
+    GtEq,
+    And,
+    Or,
+}
+
+/// 単項演算子
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOp {
+    Neg,
+    Not,
+}
+
+/// 式
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Expr {
+    pub kind: ExprKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExprKind {
+    IntLiteral(u64),
+    BoolLiteral(bool),
+    Ident(String),
+    BinaryOp {
+        op: BinOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    UnaryOp {
+        op: UnaryOp,
+        expr: Box<Expr>,
+    },
+    Call {
+        name: String,
+        args: Vec<Expr>,
+    },
+    If {
+        cond: Box<Expr>,
+        then_block: Box<Expr>,
+        else_block: Option<Box<Expr>>,
+    },
+    Loop {
+        body: Box<Expr>,
+    },
+    Block {
+        stmts: Vec<Stmt>,
+        /// 末尾の式 (ブロックの値)
+        expr: Option<Box<Expr>>,
+    },
+    ArrayLiteral(Vec<Expr>),
+    Index {
+        array: Box<Expr>,
+        index: Box<Expr>,
+    },
+}
+
+/// 文
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Stmt {
+    pub kind: StmtKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StmtKind {
+    Let { name: String, ty: Type, value: Expr },
+    Assign { name: String, value: Expr },
+    Expr(Expr),
+    Return(Option<Expr>),
+    Break,
+}
+
+/// 関数の引数
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Param {
+    pub name: String,
+    pub ty: Type,
+}
+
+/// トップレベル定義
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TopLevel {
+    FnDef {
+        name: String,
+        params: Vec<Param>,
+        return_type: Type,
+        body: Expr,
+        span: Span,
+    },
+    LetDef {
+        name: String,
+        ty: Type,
+        value: Expr,
+        span: Span,
+    },
+}
+
+/// プログラム全体
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Program {
+    pub top_levels: Vec<TopLevel>,
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,593 @@
+pub mod ast;
+
+use crate::lexer::token::{Span, Token, TokenKind};
+use ast::*;
+
+/// Parser のエラー
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}: {}",
+            self.span.line, self.span.column, self.message
+        )
+    }
+}
+
+/// 再帰下降パーサー
+pub struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    pub fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    pub fn parse_program(&mut self) -> Result<Program, ParseError> {
+        let mut top_levels = Vec::new();
+        while !self.is_at_end() {
+            top_levels.push(self.parse_top_level()?);
+        }
+        Ok(Program { top_levels })
+    }
+
+    // ---- ユーティリティ ----
+
+    fn peek(&self) -> &TokenKind {
+        &self.tokens[self.pos].kind
+    }
+
+    fn current_span(&self) -> Span {
+        self.tokens[self.pos].span
+    }
+
+    fn is_at_end(&self) -> bool {
+        self.peek() == &TokenKind::Eof
+    }
+
+    fn advance(&mut self) -> &Token {
+        let token = &self.tokens[self.pos];
+        if token.kind != TokenKind::Eof {
+            self.pos += 1;
+        }
+        token
+    }
+
+    fn expect(&mut self, expected: &TokenKind) -> Result<Span, ParseError> {
+        let span = self.current_span();
+        if self.peek() == expected {
+            self.advance();
+            Ok(span)
+        } else {
+            Err(ParseError {
+                message: format!("expected {:?}, found {:?}", expected, self.peek()),
+                span,
+            })
+        }
+    }
+
+    fn expect_ident(&mut self) -> Result<(String, Span), ParseError> {
+        let span = self.current_span();
+        if let TokenKind::Ident(name) = self.peek().clone() {
+            self.advance();
+            Ok((name, span))
+        } else {
+            Err(ParseError {
+                message: format!("expected identifier, found {:?}", self.peek()),
+                span,
+            })
+        }
+    }
+
+    // ---- トップレベル ----
+
+    fn parse_top_level(&mut self) -> Result<TopLevel, ParseError> {
+        match self.peek() {
+            TokenKind::Fn => self.parse_fn_def(),
+            TokenKind::Let => self.parse_let_def(),
+            _ => Err(ParseError {
+                message: format!("expected 'fn' or 'let', found {:?}", self.peek()),
+                span: self.current_span(),
+            }),
+        }
+    }
+
+    fn parse_fn_def(&mut self) -> Result<TopLevel, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::Fn)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LParen)?;
+        let params = self.parse_params()?;
+        self.expect(&TokenKind::RParen)?;
+        self.expect(&TokenKind::Arrow)?;
+        let return_type = self.parse_type()?;
+        let body = self.parse_block_expr()?;
+        Ok(TopLevel::FnDef {
+            name,
+            params,
+            return_type,
+            body,
+            span,
+        })
+    }
+
+    fn parse_params(&mut self) -> Result<Vec<Param>, ParseError> {
+        let mut params = Vec::new();
+        if self.peek() == &TokenKind::RParen {
+            return Ok(params);
+        }
+        loop {
+            let (name, _) = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let ty = self.parse_type()?;
+            params.push(Param { name, ty });
+            if self.peek() == &TokenKind::Comma {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(params)
+    }
+
+    fn parse_let_def(&mut self) -> Result<TopLevel, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::Let)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::Colon)?;
+        let ty = self.parse_type()?;
+        self.expect(&TokenKind::Eq)?;
+        let value = self.parse_expr()?;
+        self.expect(&TokenKind::Semicolon)?;
+        Ok(TopLevel::LetDef {
+            name,
+            ty,
+            value,
+            span,
+        })
+    }
+
+    // ---- 型 ----
+
+    fn parse_type(&mut self) -> Result<Type, ParseError> {
+        let span = self.current_span();
+        match self.peek().clone() {
+            TokenKind::Ident(name) => {
+                self.advance();
+                match name.as_str() {
+                    "u8" => Ok(Type::U8),
+                    "bool" => Ok(Type::Bool),
+                    "sprite" => {
+                        self.expect(&TokenKind::LParen)?;
+                        let size = self.parse_int_literal()?;
+                        self.expect(&TokenKind::RParen)?;
+                        Ok(Type::Sprite(size as usize))
+                    }
+                    _ => Err(ParseError {
+                        message: format!("unknown type: {name}"),
+                        span,
+                    }),
+                }
+            }
+            TokenKind::LParen => {
+                self.advance();
+                self.expect(&TokenKind::RParen)?;
+                Ok(Type::Unit)
+            }
+            TokenKind::LBracket => {
+                self.advance();
+                let elem_type = self.parse_type()?;
+                self.expect(&TokenKind::Semicolon)?;
+                let size = self.parse_int_literal()?;
+                self.expect(&TokenKind::RBracket)?;
+                Ok(Type::Array(Box::new(elem_type), size as usize))
+            }
+            _ => Err(ParseError {
+                message: format!("expected type, found {:?}", self.peek()),
+                span,
+            }),
+        }
+    }
+
+    fn parse_int_literal(&mut self) -> Result<u64, ParseError> {
+        let span = self.current_span();
+        if let TokenKind::IntLiteral(v) = self.peek() {
+            let v = *v;
+            self.advance();
+            Ok(v)
+        } else {
+            Err(ParseError {
+                message: format!("expected integer literal, found {:?}", self.peek()),
+                span,
+            })
+        }
+    }
+
+    // ---- 文 ----
+
+    fn parse_stmt(&mut self) -> Result<Stmt, ParseError> {
+        let span = self.current_span();
+        match self.peek() {
+            TokenKind::Let => {
+                self.advance();
+                let (name, _) = self.expect_ident()?;
+                self.expect(&TokenKind::Colon)?;
+                let ty = self.parse_type()?;
+                self.expect(&TokenKind::Eq)?;
+                let value = self.parse_expr()?;
+                self.expect(&TokenKind::Semicolon)?;
+                Ok(Stmt {
+                    kind: StmtKind::Let { name, ty, value },
+                    span,
+                })
+            }
+            TokenKind::Return => {
+                self.advance();
+                if self.peek() == &TokenKind::Semicolon {
+                    self.advance();
+                    Ok(Stmt {
+                        kind: StmtKind::Return(None),
+                        span,
+                    })
+                } else {
+                    let expr = self.parse_expr()?;
+                    self.expect(&TokenKind::Semicolon)?;
+                    Ok(Stmt {
+                        kind: StmtKind::Return(Some(expr)),
+                        span,
+                    })
+                }
+            }
+            TokenKind::Break => {
+                self.advance();
+                self.expect(&TokenKind::Semicolon)?;
+                Ok(Stmt {
+                    kind: StmtKind::Break,
+                    span,
+                })
+            }
+            _ => {
+                let expr = self.parse_expr()?;
+                // 代入: ident = expr;
+                if self.peek() == &TokenKind::Eq
+                    && let ExprKind::Ident(name) = expr.kind
+                {
+                    self.advance(); // '='
+                    let value = self.parse_expr()?;
+                    self.expect(&TokenKind::Semicolon)?;
+                    return Ok(Stmt {
+                        kind: StmtKind::Assign { name, value },
+                        span,
+                    });
+                }
+                self.expect(&TokenKind::Semicolon)?;
+                Ok(Stmt {
+                    kind: StmtKind::Expr(expr),
+                    span,
+                })
+            }
+        }
+    }
+
+    // ---- 式 (Pratt parsing) ----
+
+    fn parse_expr(&mut self) -> Result<Expr, ParseError> {
+        self.parse_expr_bp(0)
+    }
+
+    fn parse_expr_bp(&mut self, min_bp: u8) -> Result<Expr, ParseError> {
+        let mut lhs = self.parse_unary()?;
+
+        loop {
+            let op = match self.peek() {
+                TokenKind::Plus => BinOp::Add,
+                TokenKind::Minus => BinOp::Sub,
+                TokenKind::Star => BinOp::Mul,
+                TokenKind::Slash => BinOp::Div,
+                TokenKind::Percent => BinOp::Mod,
+                TokenKind::EqEq => BinOp::Eq,
+                TokenKind::NotEq => BinOp::NotEq,
+                TokenKind::Lt => BinOp::Lt,
+                TokenKind::Gt => BinOp::Gt,
+                TokenKind::LtEq => BinOp::LtEq,
+                TokenKind::GtEq => BinOp::GtEq,
+                TokenKind::AndAnd => BinOp::And,
+                TokenKind::OrOr => BinOp::Or,
+                _ => break,
+            };
+
+            let (l_bp, r_bp) = infix_binding_power(op);
+            if l_bp < min_bp {
+                break;
+            }
+
+            let span = lhs.span;
+            self.advance();
+            let rhs = self.parse_expr_bp(r_bp)?;
+            lhs = Expr {
+                kind: ExprKind::BinaryOp {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                },
+                span,
+            };
+        }
+
+        Ok(lhs)
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr, ParseError> {
+        let span = self.current_span();
+        match self.peek() {
+            TokenKind::Minus => {
+                self.advance();
+                let expr = self.parse_unary()?;
+                Ok(Expr {
+                    kind: ExprKind::UnaryOp {
+                        op: UnaryOp::Neg,
+                        expr: Box::new(expr),
+                    },
+                    span,
+                })
+            }
+            TokenKind::Bang => {
+                self.advance();
+                let expr = self.parse_unary()?;
+                Ok(Expr {
+                    kind: ExprKind::UnaryOp {
+                        op: UnaryOp::Not,
+                        expr: Box::new(expr),
+                    },
+                    span,
+                })
+            }
+            _ => self.parse_postfix(),
+        }
+    }
+
+    fn parse_postfix(&mut self) -> Result<Expr, ParseError> {
+        let mut expr = self.parse_primary()?;
+        loop {
+            if self.peek() == &TokenKind::LBracket {
+                let span = expr.span;
+                self.advance();
+                let index = self.parse_expr()?;
+                self.expect(&TokenKind::RBracket)?;
+                expr = Expr {
+                    kind: ExprKind::Index {
+                        array: Box::new(expr),
+                        index: Box::new(index),
+                    },
+                    span,
+                };
+            } else {
+                break;
+            }
+        }
+        Ok(expr)
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr, ParseError> {
+        let span = self.current_span();
+        match self.peek().clone() {
+            TokenKind::IntLiteral(v) => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::IntLiteral(v),
+                    span,
+                })
+            }
+            TokenKind::True => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::BoolLiteral(true),
+                    span,
+                })
+            }
+            TokenKind::False => {
+                self.advance();
+                Ok(Expr {
+                    kind: ExprKind::BoolLiteral(false),
+                    span,
+                })
+            }
+            TokenKind::Ident(name) => {
+                self.advance();
+                // 関数呼び出し
+                if self.peek() == &TokenKind::LParen {
+                    self.advance();
+                    let args = self.parse_call_args()?;
+                    self.expect(&TokenKind::RParen)?;
+                    Ok(Expr {
+                        kind: ExprKind::Call { name, args },
+                        span,
+                    })
+                } else {
+                    Ok(Expr {
+                        kind: ExprKind::Ident(name),
+                        span,
+                    })
+                }
+            }
+            TokenKind::LParen => {
+                self.advance();
+                if self.peek() == &TokenKind::RParen {
+                    self.advance();
+                    // Unit リテラル: ()
+                    return Ok(Expr {
+                        kind: ExprKind::IntLiteral(0), // Unit を 0 として扱う
+                        span,
+                    });
+                }
+                let expr = self.parse_expr()?;
+                self.expect(&TokenKind::RParen)?;
+                Ok(expr)
+            }
+            TokenKind::LBracket => {
+                self.advance();
+                let mut elems = Vec::new();
+                if self.peek() != &TokenKind::RBracket {
+                    loop {
+                        elems.push(self.parse_expr()?);
+                        if self.peek() == &TokenKind::Comma {
+                            self.advance();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                self.expect(&TokenKind::RBracket)?;
+                Ok(Expr {
+                    kind: ExprKind::ArrayLiteral(elems),
+                    span,
+                })
+            }
+            TokenKind::LBrace => Ok(self.parse_block_expr()?),
+            TokenKind::If => self.parse_if_expr(),
+            TokenKind::Loop => self.parse_loop_expr(),
+            _ => Err(ParseError {
+                message: format!("expected expression, found {:?}", self.peek()),
+                span,
+            }),
+        }
+    }
+
+    fn parse_call_args(&mut self) -> Result<Vec<Expr>, ParseError> {
+        let mut args = Vec::new();
+        if self.peek() == &TokenKind::RParen {
+            return Ok(args);
+        }
+        loop {
+            args.push(self.parse_expr()?);
+            if self.peek() == &TokenKind::Comma {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(args)
+    }
+
+    fn parse_block_expr(&mut self) -> Result<Expr, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::LBrace)?;
+        let mut stmts = Vec::new();
+        let mut tail_expr = None;
+
+        while self.peek() != &TokenKind::RBrace {
+            // 末尾式かもしれないので、まず文として解析を試みる
+            let checkpoint = self.pos;
+
+            // let, return, break は明確に文
+            match self.peek() {
+                TokenKind::Let | TokenKind::Return | TokenKind::Break => {
+                    stmts.push(self.parse_stmt()?);
+                    continue;
+                }
+                _ => {}
+            }
+
+            let expr = self.parse_expr()?;
+
+            if self.peek() == &TokenKind::Semicolon {
+                self.advance();
+                // 代入かもしれない
+                stmts.push(Stmt {
+                    kind: StmtKind::Expr(expr),
+                    span: self.tokens[checkpoint].span,
+                });
+            } else if self.peek() == &TokenKind::Eq {
+                // 代入文
+                if let ExprKind::Ident(name) = expr.kind {
+                    self.advance();
+                    let value = self.parse_expr()?;
+                    self.expect(&TokenKind::Semicolon)?;
+                    stmts.push(Stmt {
+                        kind: StmtKind::Assign { name, value },
+                        span: self.tokens[checkpoint].span,
+                    });
+                } else {
+                    return Err(ParseError {
+                        message: "invalid assignment target".to_string(),
+                        span: self.current_span(),
+                    });
+                }
+            } else if self.peek() == &TokenKind::RBrace {
+                // 末尾式
+                tail_expr = Some(Box::new(expr));
+            } else {
+                return Err(ParseError {
+                    message: format!("expected ';' or '}}', found {:?}", self.peek()),
+                    span: self.current_span(),
+                });
+            }
+        }
+
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Expr {
+            kind: ExprKind::Block {
+                stmts,
+                expr: tail_expr,
+            },
+            span,
+        })
+    }
+
+    fn parse_if_expr(&mut self) -> Result<Expr, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::If)?;
+        let cond = self.parse_expr()?;
+        let then_block = self.parse_block_expr()?;
+        let else_block = if self.peek() == &TokenKind::Else {
+            self.advance();
+            if self.peek() == &TokenKind::If {
+                Some(Box::new(self.parse_if_expr()?))
+            } else {
+                Some(Box::new(self.parse_block_expr()?))
+            }
+        } else {
+            None
+        };
+        Ok(Expr {
+            kind: ExprKind::If {
+                cond: Box::new(cond),
+                then_block: Box::new(then_block),
+                else_block,
+            },
+            span,
+        })
+    }
+
+    fn parse_loop_expr(&mut self) -> Result<Expr, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::Loop)?;
+        let body = self.parse_block_expr()?;
+        Ok(Expr {
+            kind: ExprKind::Loop {
+                body: Box::new(body),
+            },
+            span,
+        })
+    }
+}
+
+/// 二項演算子の結合力 (左結合力, 右結合力)
+fn infix_binding_power(op: BinOp) -> (u8, u8) {
+    match op {
+        BinOp::Or => (1, 2),
+        BinOp::And => (3, 4),
+        BinOp::Eq | BinOp::NotEq => (5, 6),
+        BinOp::Lt | BinOp::Gt | BinOp::LtEq | BinOp::GtEq => (7, 8),
+        BinOp::Add | BinOp::Sub => (9, 10),
+        BinOp::Mul | BinOp::Div | BinOp::Mod => (11, 12),
+    }
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1,0 +1,376 @@
+use chip8_lang::lexer::Lexer;
+use chip8_lang::parser::Parser;
+use chip8_lang::parser::ast::*;
+
+fn parse(input: &str) -> Program {
+    let mut lexer = Lexer::new(input);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    parser.parse_program().unwrap()
+}
+
+#[test]
+fn test_let_def() {
+    let prog = parse("let X: u8 = 10;");
+    assert_eq!(prog.top_levels.len(), 1);
+    match &prog.top_levels[0] {
+        TopLevel::LetDef { name, ty, .. } => {
+            assert_eq!(name, "X");
+            assert_eq!(*ty, Type::U8);
+        }
+        _ => panic!("expected LetDef"),
+    }
+}
+
+#[test]
+fn test_let_bool() {
+    let prog = parse("let flag: bool = true;");
+    match &prog.top_levels[0] {
+        TopLevel::LetDef {
+            name, ty, value, ..
+        } => {
+            assert_eq!(name, "flag");
+            assert_eq!(*ty, Type::Bool);
+            assert_eq!(value.kind, ExprKind::BoolLiteral(true));
+        }
+        _ => panic!("expected LetDef"),
+    }
+}
+
+#[test]
+fn test_sprite_type() {
+    let prog = parse("let s: sprite(2) = [0b11000000, 0b00110000];");
+    match &prog.top_levels[0] {
+        TopLevel::LetDef { ty, .. } => {
+            assert_eq!(*ty, Type::Sprite(2));
+        }
+        _ => panic!("expected LetDef"),
+    }
+}
+
+#[test]
+fn test_array_type() {
+    let prog = parse("let arr: [u8; 3] = [1, 2, 3];");
+    match &prog.top_levels[0] {
+        TopLevel::LetDef { ty, value, .. } => {
+            assert_eq!(*ty, Type::Array(Box::new(Type::U8), 3));
+            if let ExprKind::ArrayLiteral(elems) = &value.kind {
+                assert_eq!(elems.len(), 3);
+            } else {
+                panic!("expected ArrayLiteral");
+            }
+        }
+        _ => panic!("expected LetDef"),
+    }
+}
+
+#[test]
+fn test_fn_def_simple() {
+    let prog = parse("fn foo() -> () { }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef {
+            name,
+            params,
+            return_type,
+            ..
+        } => {
+            assert_eq!(name, "foo");
+            assert!(params.is_empty());
+            assert_eq!(*return_type, Type::Unit);
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_fn_def_with_params() {
+    let prog = parse("fn add(a: u8, b: u8) -> u8 { a + b }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef {
+            name,
+            params,
+            return_type,
+            body,
+            ..
+        } => {
+            assert_eq!(name, "add");
+            assert_eq!(params.len(), 2);
+            assert_eq!(params[0].name, "a");
+            assert_eq!(params[0].ty, Type::U8);
+            assert_eq!(params[1].name, "b");
+            assert_eq!(params[1].ty, Type::U8);
+            assert_eq!(*return_type, Type::U8);
+            // body should be a Block with a tail expression
+            if let ExprKind::Block { stmts, expr } = &body.kind {
+                assert!(stmts.is_empty());
+                assert!(expr.is_some());
+            } else {
+                panic!("expected Block");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_binary_op_precedence() {
+    // 1 + 2 * 3 should be 1 + (2 * 3)
+    let prog = parse("fn f() -> u8 { 1 + 2 * 3 }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(expr), ..
+            } = &body.kind
+            {
+                if let ExprKind::BinaryOp { op, rhs, .. } = &expr.kind {
+                    assert_eq!(*op, BinOp::Add);
+                    if let ExprKind::BinaryOp { op: inner_op, .. } = &rhs.kind {
+                        assert_eq!(*inner_op, BinOp::Mul);
+                    } else {
+                        panic!("expected Mul on rhs");
+                    }
+                } else {
+                    panic!("expected BinaryOp");
+                }
+            } else {
+                panic!("expected block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_comparison_ops() {
+    let prog = parse("fn f() -> bool { x > 5 }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(expr), ..
+            } = &body.kind
+            {
+                if let ExprKind::BinaryOp { op, .. } = &expr.kind {
+                    assert_eq!(*op, BinOp::Gt);
+                } else {
+                    panic!("expected BinaryOp");
+                }
+            } else {
+                panic!("expected block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_if_expr() {
+    let prog = parse("fn f(x: u8) -> u8 { if x > 5 { 1 } else { 0 } }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(expr), ..
+            } = &body.kind
+            {
+                if let ExprKind::If {
+                    else_block: Some(_),
+                    ..
+                } = &expr.kind
+                {
+                    // OK
+                } else {
+                    panic!("expected If with else");
+                }
+            } else {
+                panic!("expected block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_loop_with_break() {
+    let prog = parse(
+        "fn f() -> () {
+          loop {
+            break;
+          };
+        }",
+    );
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 1);
+                if let StmtKind::Expr(ref expr) = stmts[0].kind {
+                    assert!(matches!(expr.kind, ExprKind::Loop { .. }));
+                } else {
+                    panic!("expected Expr stmt");
+                }
+            } else {
+                panic!("expected Block");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_function_call() {
+    let prog = parse("fn f() -> () { draw(s, x, y); }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 1);
+                if let StmtKind::Expr(ref expr) = stmts[0].kind {
+                    if let ExprKind::Call { name, args } = &expr.kind {
+                        assert_eq!(name, "draw");
+                        assert_eq!(args.len(), 3);
+                    } else {
+                        panic!("expected Call");
+                    }
+                }
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_let_stmt() {
+    let prog = parse("fn f() -> () { let x: u8 = 42; }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 1);
+                if let StmtKind::Let { name, ty, .. } = &stmts[0].kind {
+                    assert_eq!(name, "x");
+                    assert_eq!(*ty, Type::U8);
+                } else {
+                    panic!("expected Let");
+                }
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_assign_stmt() {
+    let prog = parse("fn f() -> () { x = 10; }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 1);
+                if let StmtKind::Assign { name, .. } = &stmts[0].kind {
+                    assert_eq!(name, "x");
+                } else {
+                    panic!("expected Assign");
+                }
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_unary_neg() {
+    let prog = parse("fn f() -> u8 { -x }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(expr), ..
+            } = &body.kind
+            {
+                if let ExprKind::UnaryOp { op, .. } = &expr.kind {
+                    assert_eq!(*op, UnaryOp::Neg);
+                } else {
+                    panic!("expected UnaryOp");
+                }
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_unary_not() {
+    let prog = parse("fn f() -> bool { !flag }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(expr), ..
+            } = &body.kind
+            {
+                if let ExprKind::UnaryOp { op, .. } = &expr.kind {
+                    assert_eq!(*op, UnaryOp::Not);
+                } else {
+                    panic!("expected UnaryOp");
+                }
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_design_doc_full_parse() {
+    let source = r#"
+-- 定数定義
+let BOARD_W: u8 = 10;
+let BOARD_H: u8 = 20;
+
+-- スプライト定義 (バイナリリテラル)
+let block_sprite: sprite(1) = [0b11000000];
+
+-- 関数定義
+fn draw_block(x: u8, y: u8) -> () {
+  draw(block_sprite, x, y);
+}
+
+-- 条件分岐 (if 式)
+fn clamp(val: u8, max: u8) -> u8 {
+  if val > max { max } else { val }
+}
+
+-- ループ (loop + break)
+fn game_loop() -> () {
+  loop {
+    let key: u8 = wait_key();
+    if key == 5 {
+      break;
+    };
+  };
+}
+
+-- エントリーポイント
+fn main() -> () {
+  clear();
+  game_loop();
+}
+"#;
+    let prog = parse(source);
+    // 5 top-level definitions
+    assert_eq!(prog.top_levels.len(), 7);
+}
+
+#[test]
+fn test_return_stmt() {
+    let prog = parse("fn f() -> u8 { return 42; }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 1);
+                assert!(matches!(stmts[0].kind, StmtKind::Return(Some(_))));
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_parse_error() {
+    let mut lexer = Lexer::new("fn 42");
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    assert!(parser.parse_program().is_err());
+}


### PR DESCRIPTION
## 実装計画

再帰下降パーサーで AST を構築する。

### やること

1. **AST 型定義** (`src/parser/ast.rs`)
   - `Program`: トップレベル定義のリスト
   - `TopLevel`: `FnDef` (関数定義), `LetDef` (定数/スプライト定義)
   - `Stmt`: `Let`, `Assign`, `Expr`, `Return`, `Break`
   - `Expr`: `Literal`, `Ident`, `BinaryOp`, `UnaryOp`, `Call`, `If`, `Loop`, `Block`, `Index`, `ArrayLiteral`
   - `Type`: `U8`, `Bool`, `Unit`, `Array(Box<Type>, usize)`, `Sprite(usize)`

2. **Parser 本体** (`src/parser/mod.rs`)
   - トークン列を受け取り AST を生成
   - 演算子の優先順位: Pratt parsing
   - トップレベル: `fn` / `let` の解析
   - 式: リテラル、変数参照、関数呼び出し、二項演算、if 式、loop 式、ブロック
   - 文: let 束縛、代入、式文、return、break
   - 型注釈のパース

3. **テスト** (`tests/parser_tests.rs`)
   - let 束縛の解析
   - 関数定義の解析
   - 式の解析 (二項演算、優先順位、if、loop)
   - DESIGN.md の構文イメージ全体をパースできるかのテスト

### 完了条件

- `cargo test` で全テスト合格
- `cargo clippy` で警告なし
- `cargo fmt --check` で差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)