### PR TITLE
Phase 5: Emitter & CLI (バイナリ出力)

### DIFF
--- a/examples/hello.ch8l
+++ b/examples/hello.ch8l
@@ -1,0 +1,13 @@
+-- hello.ch8l: 画面に数字を表示する最小サンプル
+
+let digit_sprite: sprite(1) = [0b11110000];
+
+fn main() -> () {
+  clear();
+  -- 画面中央付近に数字スプライトを描画
+  let x: u8 = 28;
+  let y: u8 = 14;
+  draw(digit_sprite, x, y);
+  -- キー入力待ちで停止
+  let k: u8 = wait_key();
+}

--- a/src/emitter/mod.rs
+++ b/src/emitter/mod.rs
@@ -1,0 +1,36 @@
+use std::fs;
+use std::path::Path;
+
+/// ROM の最大サイズ (4KB - 0x200 = 3584 バイト)
+const MAX_ROM_SIZE: usize = 4096 - 0x200;
+
+/// Emitter のエラー
+#[derive(Debug)]
+pub struct EmitError {
+    pub message: String,
+}
+
+impl std::fmt::Display for EmitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+/// バイトコードを `.ch8` ファイルとして書き出す
+pub fn emit(bytes: &[u8], output_path: &Path) -> Result<(), EmitError> {
+    if bytes.len() > MAX_ROM_SIZE {
+        return Err(EmitError {
+            message: format!(
+                "ROM size {} bytes exceeds maximum {} bytes",
+                bytes.len(),
+                MAX_ROM_SIZE
+            ),
+        });
+    }
+
+    fs::write(output_path, bytes).map_err(|e| EmitError {
+        message: format!("failed to write output file: {e}"),
+    })?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod analyzer;
 pub mod codegen;
+pub mod emitter;
 pub mod lexer;
 pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,76 @@
+use std::path::Path;
+use std::process;
+
+use chip8_lang::analyzer::Analyzer;
+use chip8_lang::codegen::CodeGen;
+use chip8_lang::emitter;
+use chip8_lang::lexer::Lexer;
+use chip8_lang::parser::Parser;
+
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: chip8-lang <source.ch8l>");
+        process::exit(1);
+    }
+
+    let input_path = Path::new(&args[1]);
+    let source = match std::fs::read_to_string(input_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error reading file '{}': {}", input_path.display(), e);
+            process::exit(1);
+        }
+    };
+
+    // Lexer
+    let mut lexer = Lexer::new(&source);
+    let tokens = match lexer.tokenize() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Lexer error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // Parser
+    let mut parser = Parser::new(tokens);
+    let program = match parser.parse_program() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Parse error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // Analyzer
+    let mut analyzer = Analyzer::new();
+    if let Err(errors) = analyzer.analyze(&program) {
+        for e in &errors {
+            eprintln!("Analyze error: {e}");
+        }
+        process::exit(1);
+    }
+
+    // CodeGen
+    let mut codegen = CodeGen::new();
+    let bytes = codegen.generate(&program);
+
+    // Emitter
+    let output_path = input_path.with_extension("ch8");
+    match emitter::emit(&bytes, &output_path) {
+        Ok(()) => {
+            println!(
+                "Compiled {} -> {} ({} bytes)",
+                input_path.display(),
+                output_path.display(),
+                bytes.len()
+            );
+        }
+        Err(e) => {
+            eprintln!("Emit error: {e}");
+            process::exit(1);
+        }
+    }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,109 @@
+use chip8_lang::analyzer::Analyzer;
+use chip8_lang::codegen::CodeGen;
+use chip8_lang::emitter;
+use chip8_lang::lexer::Lexer;
+use chip8_lang::parser::Parser;
+use std::path::Path;
+
+fn compile_to_bytes(source: &str) -> Vec<u8> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().unwrap();
+    let mut parser = Parser::new(tokens);
+    let program = parser.parse_program().unwrap();
+    let mut analyzer = Analyzer::new();
+    analyzer.analyze(&program).unwrap();
+    let mut codegen = CodeGen::new();
+    codegen.generate(&program)
+}
+
+#[test]
+fn test_full_pipeline() {
+    let source = r#"
+        fn main() -> () {
+            clear();
+        }
+    "#;
+    let bytes = compile_to_bytes(source);
+    assert!(!bytes.is_empty());
+    // 先頭は JP main
+    assert_eq!(bytes[0] & 0xF0, 0x10);
+}
+
+#[test]
+fn test_emit_to_file() {
+    let source = r#"
+        fn main() -> () {
+            clear();
+        }
+    "#;
+    let bytes = compile_to_bytes(source);
+
+    let tmp_path = std::env::temp_dir().join("test_output.ch8");
+    emitter::emit(&bytes, &tmp_path).unwrap();
+
+    let read_back = std::fs::read(&tmp_path).unwrap();
+    assert_eq!(bytes, read_back);
+
+    // cleanup
+    let _ = std::fs::remove_file(&tmp_path);
+}
+
+#[test]
+fn test_rom_size_limit() {
+    // 3584 バイトを超えるROMはエラー
+    let big_bytes = vec![0u8; 4000];
+    let tmp_path = std::env::temp_dir().join("test_big.ch8");
+    let result = emitter::emit(&big_bytes, &tmp_path);
+    assert!(result.is_err());
+    let _ = std::fs::remove_file(&tmp_path);
+}
+
+#[test]
+fn test_hello_example_compiles() {
+    let source =
+        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/hello.ch8l"))
+            .unwrap();
+    let bytes = compile_to_bytes(&source);
+    assert!(!bytes.is_empty());
+    assert_eq!(bytes[0] & 0xF0, 0x10);
+}
+
+#[test]
+fn test_design_doc_program_e2e() {
+    let source = r#"
+        let BOARD_W: u8 = 10;
+        let BOARD_H: u8 = 20;
+        let block_sprite: sprite(1) = [0b11000000];
+
+        fn draw_block(x: u8, y: u8) -> () {
+            draw(block_sprite, x, y);
+        }
+
+        fn clamp(val: u8, max: u8) -> u8 {
+            if val > max { max } else { val }
+        }
+
+        fn game_loop() -> () {
+            loop {
+                let key: u8 = wait_key();
+                if key == 5 {
+                    break;
+                };
+            };
+        }
+
+        fn main() -> () {
+            clear();
+            game_loop();
+        }
+    "#;
+    let bytes = compile_to_bytes(source);
+    assert!(!bytes.is_empty());
+
+    // ファイルに書き出せることも確認
+    let tmp_path = std::env::temp_dir().join("test_design.ch8");
+    emitter::emit(&bytes, &tmp_path).unwrap();
+    let read_back = std::fs::read(&tmp_path).unwrap();
+    assert_eq!(bytes, read_back);
+    let _ = std::fs::remove_file(&tmp_path);
+}


### PR DESCRIPTION
## 実装計画

バイトコードを `.ch8` バイナリファイルとして出力し、CLIを完成させる。

### やること

1. **Emitter** (`src/emitter/mod.rs`)
   - バイトコード (Vec<u8>) を `.ch8` ファイルとして書き出し
   - ROM サイズの検証 (4KB - 0x200 = 3,584 バイト以内)

2. **CLI** (`src/main.rs`)
   - コマンドライン引数で `.ch8l` ファイルを受け取り
   - Lexer → Parser → Analyzer → CodeGen → Emitter のパイプライン実行
   - エラーメッセージの表示
   - 出力ファイル名の自動決定 (`.ch8l` → `.ch8`)

3. **サンプルプログラム** (`examples/hello.ch8l`)
   - 最小限の動作確認用サンプル

4. **E2E テスト** (`tests/integration/`)
   - `.ch8l` → `.ch8` のパイプラインテスト

### 完了条件

- `cargo test` で全テスト合格
- `cargo clippy` で警告なし
- `cargo fmt --check` で差分なし
- `cargo run -- examples/hello.ch8l` で `.ch8` ファイルが生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)