### PR TITLE
fix: 関数本体の結果レジスタが V0 にコピーされずに RET する (#23)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -157,7 +157,12 @@ impl CodeGen {
                 }
                 self.local_var_count = self.next_free_reg;
 
-                self.codegen_expr(body);
+                let result = self.codegen_expr(body);
+                if let Some(reg) = result.register()
+                    && reg != Register::V0
+                {
+                    self.emit_op(Opcode::LdReg(Register::V0, reg));
+                }
                 self.emit_op(Opcode::Ret);
             }
         }

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -274,3 +274,24 @@ fn test_pipe_compiles() {
         "expected CALL instruction"
     );
 }
+
+#[test]
+fn test_function_body_result_copied_to_v0() {
+    // draw() は VF を返す。関数本体の結果が VF の場合、RET 前に LD V0, VF が必要
+    let bytes = compile(
+        "let sprite: sprite(1) = [0b11110000];
+         fn check(x: u8, y: u8) -> bool {
+            draw(sprite, x, y)
+         }
+         fn main() -> () {
+            let c: bool = check(0, 0);
+         }",
+    );
+    // check 関数内に LD V0, VF (8F0x パターンではなく 80F0) が含まれるはず
+    // 8XY0 = LD Vx, Vy → 80F0 = LD V0, VF
+    let has_ld_v0_vf = bytes.chunks(2).any(|c| c[0] == 0x80 && c[1] == 0xF0);
+    assert!(
+        has_ld_v0_vf,
+        "expected LD V0, VF before RET in function returning draw result"
+    );
+}


### PR DESCRIPTION
## Summary
- 関数本体の評価結果が V0 以外のレジスタ (例: draw() の VF) にあるとき、RET 前に `LD V0, reg` を発行するようにした
- これにより `draw_piece()` のような draw を返す関数が正しい値を返すようになる

## Test plan
- [x] `test_function_body_result_copied_to_v0` — draw を返す関数で `LD V0, VF` が生成されることを検証
- [x] `cargo test` — 94 テスト全通過
- [x] `cargo clippy` / `cargo fmt --check` — クリーン

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)