### PR TITLE
feat: random_enum ビルトイン関数を追加 (#27)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -91,6 +91,8 @@ pub enum AnalyzeErrorKind {
     },
     /// 不明な型名
     UnknownType(String),
+    /// random_enum の引数が enum 名でない
+    RandomEnumArgNotEnum(String),
 }
 
 /// 意味解析エラー
@@ -201,6 +203,9 @@ impl std::fmt::Display for AnalyzeError {
                 missing.join(", ")
             ),
             AnalyzeErrorKind::UnknownType(name) => write!(f, "unknown type: '{name}'"),
+            AnalyzeErrorKind::RandomEnumArgNotEnum(name) => {
+                write!(f, "random_enum argument must be an enum name, got '{name}'")
+            }
         }
     }
 }
@@ -475,6 +480,37 @@ impl Analyzer {
                 }
             }
             ExprKind::BuiltinCall { builtin, args } => {
+                // random_enum は引数が型名 (enum 名) なので特殊処理
+                if *builtin == BuiltinFunction::RandomEnum {
+                    if args.len() != 1 {
+                        self.errors.push(AnalyzeError {
+                            kind: AnalyzeErrorKind::BuiltinArgCountMismatch {
+                                builtin: *builtin,
+                                expected: 1,
+                                found: args.len(),
+                            },
+                        });
+                        return None;
+                    }
+                    if let ExprKind::Ident(name) = &args[0].kind {
+                        if self.enums.contains_key(name) {
+                            return Some(Type::UserEnum(name.clone()));
+                        } else {
+                            self.errors.push(AnalyzeError {
+                                kind: AnalyzeErrorKind::RandomEnumArgNotEnum(name.clone()),
+                            });
+                            return None;
+                        }
+                    } else {
+                        self.errors.push(AnalyzeError {
+                            kind: AnalyzeErrorKind::RandomEnumArgNotEnum(
+                                "<non-identifier>".to_string(),
+                            ),
+                        });
+                        return None;
+                    }
+                }
+
                 let (param_types, return_type) = builtin.signature();
                 if args.len() != param_types.len() {
                     self.errors.push(AnalyzeError {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -699,6 +699,60 @@ impl CodeGen {
                 }
                 ValueLocation::InRegister(Register::V0)
             }
+            BuiltinFunction::RandomEnum => {
+                // args[0] は Ident(enum_name)
+                let enum_name = if let ExprKind::Ident(name) = &args[0].kind {
+                    name.clone()
+                } else {
+                    return ValueLocation::Void;
+                };
+
+                // バリアント数を取得
+                let count = self
+                    .enum_variant_values
+                    .keys()
+                    .filter(|(e, _)| *e == enum_name)
+                    .count() as u8;
+
+                let res = self.alloc_temp_register();
+
+                if count == 0 {
+                    self.emit_op(Opcode::LdImm(res.into(), 0));
+                    return ValueLocation::InRegister(res.into());
+                }
+
+                // mask = next_power_of_two(count) - 1
+                let mask = count.next_power_of_two() - 1;
+
+                if count.is_power_of_two() {
+                    // count が 2 の冪: RND で直接生成
+                    self.emit_op(Opcode::Rnd(res.into(), mask));
+                } else {
+                    // 拒否サンプリング: mask で生成し、count 以上なら再試行
+                    let tmp = self.alloc_temp_register();
+                    let loop_addr = self.current_addr();
+                    self.emit_op(Opcode::Rnd(res.into(), mask));
+                    // tmp = res をコピーし、tmp -= count で比較
+                    self.emit_op(Opcode::LdImm(tmp.into(), count));
+                    // res >= count かチェック: SUB は Vx = Vx - Vy, VF = NOT borrow
+                    // res が tmp (=count) にコピーされている代わりに、
+                    // SeImm で直接比較: res == count なら再試行
+                    // ただし SE/SNE は即値比較のみ。count 以上の判定は SUB が必要。
+                    // SUBN: tmp = count - res, VF=1 なら count >= res (つまり res <= count)
+                    // VF=0 なら count < res (res > count) → 再試行
+                    // res == count の場合も再試行が必要
+                    // → Sub: tmp(=count) - res → tmp = count - res
+                    //   VF=1: count >= res → res <= count
+                    //   res < count: OK, res == count: NG, res > count: NG
+                    // SUBN(tmp, res) → tmp = res - tmp = res - count, VF = 1 if res >= count
+                    self.emit_op(Opcode::Subn(tmp.into(), res.into()));
+                    // VF == 1 → res >= count → 再試行
+                    self.emit_op(Opcode::SneImm(Register::VF, 1));
+                    self.emit_op(Opcode::Jp(loop_addr));
+                }
+
+                ValueLocation::InRegister(res.into())
+            }
         }
     }
 

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -178,6 +178,8 @@ pub enum BuiltinFunction {
     Bcd,
     /// draw_digit(v: u8, x: u8, y: u8) - フォント数字描画 (FX29 + DXYN)
     DrawDigit,
+    /// random_enum(EnumName) -> EnumName - enum のランダム生成
+    RandomEnum,
 }
 
 impl BuiltinFunction {
@@ -194,6 +196,7 @@ impl BuiltinFunction {
             "random" => Some(Self::Random),
             "bcd" => Some(Self::Bcd),
             "draw_digit" => Some(Self::DrawDigit),
+            "random_enum" => Some(Self::RandomEnum),
             _ => None,
         }
     }
@@ -211,6 +214,7 @@ impl BuiltinFunction {
             Self::Random => "random",
             Self::Bcd => "bcd",
             Self::DrawDigit => "draw_digit",
+            Self::RandomEnum => "random_enum",
         }
     }
 
@@ -227,6 +231,8 @@ impl BuiltinFunction {
             Self::Random => (vec![Type::U8], Type::U8),
             Self::Bcd => (vec![Type::U8], Type::Unit),
             Self::DrawDigit => (vec![Type::U8, Type::U8, Type::U8], Type::Unit),
+            // RandomEnum は analyzer で特殊処理されるためプレースホルダ
+            Self::RandomEnum => (vec![Type::U8], Type::U8),
         }
     }
 }

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -463,3 +463,44 @@ fn test_unknown_type() {
         AnalyzeErrorKind::UnknownType("Foo".to_string()),
     );
 }
+
+#[test]
+fn test_random_enum_ok() {
+    analyze_ok(
+        "enum Piece { I, O, T, S, Z, L, J }
+         fn main() -> Piece { random_enum(Piece) }",
+    );
+}
+
+#[test]
+fn test_random_enum_returns_enum_type() {
+    // random_enum(Piece) の戻り値を Piece 型変数に代入できること
+    analyze_ok(
+        "enum Dir { Up, Down, Left, Right }
+         fn main() -> Dir {
+            let d: Dir = random_enum(Dir);
+            d
+         }",
+    );
+}
+
+#[test]
+fn test_random_enum_not_enum_name() {
+    analyze_err_kind(
+        "fn main() -> u8 { random_enum(Foo) }",
+        AnalyzeErrorKind::RandomEnumArgNotEnum("Foo".to_string()),
+    );
+}
+
+#[test]
+fn test_random_enum_wrong_arg_count() {
+    analyze_err_kind(
+        "enum A { X }
+         fn main() -> A { random_enum(A, A) }",
+        AnalyzeErrorKind::BuiltinArgCountMismatch {
+            builtin: BuiltinFunction::RandomEnum,
+            expected: 1,
+            found: 2,
+        },
+    );
+}

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -295,3 +295,33 @@ fn test_function_body_result_copied_to_v0() {
         "expected LD V0, VF before RET in function returning draw result"
     );
 }
+
+#[test]
+fn test_random_enum_generates_rnd() {
+    let bytes = compile(
+        "enum Piece { I, O, T, S, Z, L, J }
+         fn main() -> Piece { random_enum(Piece) }",
+    );
+    // RND 命令 (CXKK) が含まれること
+    let has_rnd = bytes.chunks(2).any(|c| (c[0] & 0xF0) == 0xC0);
+    assert!(has_rnd, "expected RND instruction for random_enum");
+}
+
+#[test]
+fn test_random_enum_power_of_two() {
+    // 4 バリアント (2の冪) → mask = 3, 拒否サンプリング不要
+    let bytes = compile(
+        "enum Dir { Up, Down, Left, Right }
+         fn main() -> Dir { random_enum(Dir) }",
+    );
+    let has_rnd = bytes.chunks(2).any(|c| (c[0] & 0xF0) == 0xC0);
+    assert!(has_rnd, "expected RND instruction for random_enum");
+    // RND Vx, 0x03 (mask = 3) が含まれるはず
+    let has_rnd_mask3 = bytes
+        .chunks(2)
+        .any(|c| (c[0] & 0xF0) == 0xC0 && c[1] == 0x03);
+    assert!(
+        has_rnd_mask3,
+        "expected RND with mask 0x03 for 4-variant enum"
+    );
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -528,3 +528,30 @@ fn test_pipe_chain() {
         _ => panic!("expected FnDef"),
     }
 }
+
+#[test]
+fn test_random_enum_parses_as_builtin_call() {
+    let prog = parse(
+        "enum Piece { I, O, T, S, Z, L, J }
+         fn main() -> Piece { random_enum(Piece) }",
+    );
+    match &prog.top_levels[1] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(tail), ..
+            } = &body.kind
+            {
+                assert!(matches!(
+                    &tail.kind,
+                    ExprKind::BuiltinCall {
+                        builtin: BuiltinFunction::RandomEnum,
+                        ..
+                    }
+                ));
+            } else {
+                panic!("expected Block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}


### PR DESCRIPTION
## Summary
- enum のバリアントからランダムに1つを選ぶ `random_enum(EnumName)` 組み込み関数を追加
- バリアント数が2の冪の場合は RND マスクで直接生成、それ以外は拒否サンプリングで均一分布を実現
- Parser / Analyzer / CodeGen の全レイヤで対応

## Test plan
- [x] `random_enum(Piece)` が `BuiltinCall` にパースされること
- [x] Analyzer: 正常系 (`random_enum(Dir)` → `Dir` 型)
- [x] Analyzer: エラー系 (未定義 enum、引数数不一致)
- [x] CodeGen: RND 命令が出力に含まれること
- [x] CodeGen: 4バリアント enum で mask=0x03 が使われること
- [x] `cargo test && cargo clippy && cargo fmt --check` 通過

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)