### PR TITLE
feat: 末尾再帰最適化 (TCO) を実装 (#26)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -73,6 +73,12 @@ pub struct CodeGen {
     forward_refs: Vec<ForwardRef>,
     /// ループごとの break 先パッチオフセットのスタック
     loop_break_offsets: Vec<Vec<ByteOffset>>,
+    /// 現在コード生成中の関数名 (TCO 検出用)
+    current_fn_name: Option<String>,
+    /// 現在の関数の先頭アドレス (TCO ジャンプ先)
+    current_fn_start_addr: Option<Addr>,
+    /// 現在の関数のパラメータ数 (TCO 引数コピー用)
+    current_fn_param_count: u8,
 }
 
 impl CodeGen {
@@ -91,6 +97,9 @@ impl CodeGen {
             local_var_count: 0,
             forward_refs: Vec::new(),
             loop_break_offsets: Vec::new(),
+            current_fn_name: None,
+            current_fn_start_addr: None,
+            current_fn_param_count: 0,
         }
     }
 
@@ -157,13 +166,21 @@ impl CodeGen {
                 }
                 self.local_var_count = self.next_free_reg;
 
-                let result = self.codegen_expr(body);
+                // TCO 用に現在の関数情報を記録
+                self.current_fn_name = Some(name.clone());
+                self.current_fn_start_addr = Some(addr);
+                self.current_fn_param_count = params.len() as u8;
+
+                let result = self.codegen_expr_tail(body);
                 if let Some(reg) = result.register()
                     && reg != Register::V0
                 {
                     self.emit_op(Opcode::LdReg(Register::V0, reg));
                 }
                 self.emit_op(Opcode::Ret);
+
+                self.current_fn_name = None;
+                self.current_fn_start_addr = None;
             }
         }
 
@@ -292,6 +309,86 @@ impl CodeGen {
     }
 
     // ---- コード生成 ----
+
+    /// 末尾位置の式をコード生成 (TCO 対象の自己再帰を検出)
+    fn codegen_expr_tail(&mut self, expr: &Expr) -> ValueLocation {
+        match &expr.kind {
+            // 末尾位置での自己再帰呼び出し → TCO
+            ExprKind::Call { name, args } if self.current_fn_name.as_deref() == Some(name) => {
+                let fn_start = self.current_fn_start_addr.unwrap();
+                let param_count = self.current_fn_param_count;
+
+                // 全引数を temp レジスタに評価
+                let mut arg_regs = Vec::new();
+                for arg in args {
+                    if let Some(reg) = self.codegen_expr(arg).register() {
+                        arg_regs.push(reg);
+                    }
+                }
+
+                // temp → V0, V1, ... にコピー (パラメータ上書き)
+                for i in 0..param_count {
+                    let target: Register = UserRegister::new(i).into();
+                    if i < arg_regs.len() as u8 && arg_regs[i as usize] != target {
+                        self.emit_op(Opcode::LdReg(target, arg_regs[i as usize]));
+                    }
+                }
+
+                // 関数先頭にジャンプ (CALL + RET の代わり)
+                self.emit_op(Opcode::Jp(fn_start));
+                ValueLocation::Void
+            }
+            // if-else: 両ブランチを末尾位置として再帰
+            ExprKind::If {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                let Some(cond_reg) = self.codegen_expr(cond).register() else {
+                    return ValueLocation::Void;
+                };
+                self.emit_op(Opcode::SneImm(cond_reg, 0x00));
+                let jp_else_offset = self.emit_placeholder();
+
+                let then_loc = self.codegen_expr_tail(then_block);
+
+                if let Some(else_block) = else_block {
+                    let jp_end_offset = self.emit_placeholder();
+
+                    let else_addr = self.current_addr();
+                    self.patch_at(jp_else_offset, Opcode::Jp(else_addr));
+
+                    let else_loc = self.codegen_expr_tail(else_block);
+
+                    let end_addr = self.current_addr();
+                    self.patch_at(jp_end_offset, Opcode::Jp(end_addr));
+
+                    match (then_loc, else_loc) {
+                        (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
+                        (ValueLocation::InRegister(r), _) => ValueLocation::InRegister(r),
+                        _ => ValueLocation::Void,
+                    }
+                } else {
+                    let end_addr = self.current_addr();
+                    self.patch_at(jp_else_offset, Opcode::Jp(end_addr));
+                    then_loc
+                }
+            }
+            // block: 末尾式を末尾位置として再帰
+            ExprKind::Block { stmts, expr } => {
+                for stmt in stmts {
+                    self.codegen_stmt(stmt);
+                }
+                if let Some(tail) = expr {
+                    self.codegen_expr_tail(tail)
+                } else {
+                    ValueLocation::Void
+                }
+            }
+            // その他: 通常のコード生成にフォールバック
+            _ => self.codegen_expr(expr),
+        }
+    }
 
     fn codegen_expr(&mut self, expr: &Expr) -> ValueLocation {
         match &expr.kind {

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -325,3 +325,43 @@ fn test_random_enum_power_of_two() {
         "expected RND with mask 0x03 for 4-variant enum"
     );
 }
+
+#[test]
+fn test_tco_self_recursion_generates_jp() {
+    // 末尾再帰は CALL ではなく JP にコンパイルされるべき
+    let bytes = compile(
+        "fn count(n: u8) -> u8 {
+            if n == 0 { 0 } else { count(n - 1) }
+         }
+         fn main() -> u8 { count(5) }",
+    );
+    // count 関数内の末尾再帰は JP (1NNN) であるべき
+    // main 関数からの count 呼び出しは CALL (2NNN) であるべき
+    // JP は最初の命令 (main へ) と count 内の TCO とループ的なものがある
+    let jp_count = bytes.chunks(2).filter(|c| (c[0] & 0xF0) == 0x10).count();
+    let call_count = bytes.chunks(2).filter(|c| (c[0] & 0xF0) == 0x20).count();
+    // CALL は main→count の1回のみ (TCO 分は JP に変換)
+    assert_eq!(call_count, 1, "expected exactly 1 CALL (main→count)");
+    // JP は: main へのジャンプ + if-else の条件ジャンプ + TCO ジャンプ (最低3つ)
+    assert!(
+        jp_count >= 3,
+        "expected at least 3 JP instructions (main + if-else + TCO)"
+    );
+}
+
+#[test]
+fn test_non_tail_recursion_generates_call() {
+    // 非末尾位置の再帰は通常の CALL のまま
+    let bytes = compile(
+        "fn add_one(n: u8) -> u8 {
+            if n == 0 { 0 } else { add_one(n - 1) + 1 }
+         }
+         fn main() -> u8 { add_one(3) }",
+    );
+    // add_one(n-1) + 1 は末尾位置ではない → CALL が2つ (main→add_one, add_one→add_one)
+    let call_count = bytes.chunks(2).filter(|c| (c[0] & 0xF0) == 0x20).count();
+    assert_eq!(
+        call_count, 2,
+        "expected 2 CALL instructions (non-tail recursion)"
+    );
+}


### PR DESCRIPTION
## Summary
- 末尾位置の自己再帰呼び出しを CALL+RET → 引数更新+JP にコンパイル
- if-else・block の末尾位置を再帰的に検出する `codegen_expr_tail` メソッドを追加
- CHIP-8 のスタック 16 段制約下でゲームループの再帰が実用可能に

## Test plan
- [x] 末尾再帰 `count(n-1)` が JP にコンパイルされ、CALL が1つのみ
- [x] 非末尾再帰 `add_one(n-1) + 1` は通常の CALL のまま
- [x] 既存テスト全 127 件通過
- [x] `cargo test && cargo clippy && cargo fmt --check` 通過

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)