### PR TITLE
feat: struct 型とフィールドアクセス構文を追加 (#25, #28)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -93,6 +93,19 @@ pub enum AnalyzeErrorKind {
     UnknownType(String),
     /// random_enum の引数が enum 名でない
     RandomEnumArgNotEnum(String),
+    /// 未定義の struct
+    UndefinedStruct(String),
+    /// 未定義のフィールド
+    UndefinedField { struct_name: String, field: String },
+    /// struct リテラルで必須フィールドが不足
+    MissingFields {
+        struct_name: String,
+        missing: Vec<String>,
+    },
+    /// struct リテラルでフィールドが重複
+    DuplicateField { struct_name: String, field: String },
+    /// フィールドアクセスの対象が struct でない
+    FieldAccessOnNonStruct(Type),
 }
 
 /// 意味解析エラー
@@ -206,6 +219,26 @@ impl std::fmt::Display for AnalyzeError {
             AnalyzeErrorKind::RandomEnumArgNotEnum(name) => {
                 write!(f, "random_enum argument must be an enum name, got '{name}'")
             }
+            AnalyzeErrorKind::UndefinedStruct(name) => {
+                write!(f, "undefined struct: '{name}'")
+            }
+            AnalyzeErrorKind::UndefinedField { struct_name, field } => {
+                write!(f, "undefined field '{field}' in struct '{struct_name}'")
+            }
+            AnalyzeErrorKind::MissingFields {
+                struct_name,
+                missing,
+            } => write!(
+                f,
+                "missing fields in struct '{struct_name}': {}",
+                missing.join(", ")
+            ),
+            AnalyzeErrorKind::DuplicateField { struct_name, field } => {
+                write!(f, "duplicate field '{field}' in struct '{struct_name}'")
+            }
+            AnalyzeErrorKind::FieldAccessOnNonStruct(ty) => {
+                write!(f, "field access on non-struct type: {ty:?}")
+            }
         }
     }
 }
@@ -225,6 +258,8 @@ pub struct Analyzer {
     functions: HashMap<String, FnSig>,
     /// ユーザー定義 enum (名前 → variant リスト)
     enums: HashMap<String, Vec<String>>,
+    /// ユーザー定義 struct (名前 → フィールド定義リスト)
+    structs: HashMap<String, Vec<StructField>>,
     /// ローカルスコープスタック
     locals: Vec<HashMap<String, Type>>,
     /// 現在の関数の戻り値型
@@ -241,6 +276,7 @@ impl Analyzer {
             globals: HashMap::new(),
             functions: HashMap::new(),
             enums: HashMap::new(),
+            structs: HashMap::new(),
             locals: Vec::new(),
             current_return_type: None,
             loop_depth: 0,
@@ -272,6 +308,9 @@ impl Analyzer {
                 TopLevel::EnumDef { name, variants, .. } => {
                     self.enums.insert(name.clone(), variants.clone());
                 }
+                TopLevel::StructDef { name, fields, .. } => {
+                    self.structs.insert(name.clone(), fields.clone());
+                }
             }
         }
 
@@ -282,7 +321,7 @@ impl Analyzer {
             });
         }
 
-        // UserEnum 型の存在チェック
+        // UserType 型の存在チェック (enum または struct)
         for top in &program.top_levels {
             let types_to_check: Vec<&Type> = match top {
                 TopLevel::FnDef {
@@ -295,11 +334,12 @@ impl Analyzer {
                     ts
                 }
                 TopLevel::LetDef { ty, .. } => vec![ty],
-                TopLevel::EnumDef { .. } => vec![],
+                TopLevel::EnumDef { .. } | TopLevel::StructDef { .. } => vec![],
             };
             for ty in types_to_check {
-                if let Type::UserEnum(name) = ty
+                if let Type::UserType(name) = ty
                     && !self.enums.contains_key(name)
+                    && !self.structs.contains_key(name)
                 {
                     self.errors.push(AnalyzeError {
                         kind: AnalyzeErrorKind::UnknownType(name.clone()),
@@ -365,7 +405,7 @@ impl Analyzer {
                     self.locals.pop();
                     self.current_return_type = None;
                 }
-                TopLevel::EnumDef { .. } => {}
+                TopLevel::EnumDef { .. } | TopLevel::StructDef { .. } => {}
             }
         }
 
@@ -401,7 +441,7 @@ impl Analyzer {
             }
             (Type::Sprite(_), Type::Sprite(_)) => true,
             (Type::Sprite(n), Type::Array(elem, m)) => *n == *m && **elem == Type::U8,
-            (Type::UserEnum(a), Type::UserEnum(b)) => a == b,
+            (Type::UserType(a), Type::UserType(b)) => a == b, // enum or struct, same name
             _ => false,
         }
     }
@@ -494,7 +534,7 @@ impl Analyzer {
                     }
                     if let ExprKind::Ident(name) = &args[0].kind {
                         if self.enums.contains_key(name) {
-                            return Some(Type::UserEnum(name.clone()));
+                            return Some(Type::UserType(name.clone()));
                         } else {
                             self.errors.push(AnalyzeError {
                                 kind: AnalyzeErrorKind::RandomEnumArgNotEnum(name.clone()),
@@ -641,7 +681,7 @@ impl Analyzer {
                 let scr_ty = self.type_check_expr(scrutinee);
                 if let Some(ref st) = scr_ty
                     && *st != Type::U8
-                    && !matches!(st, Type::UserEnum(_))
+                    && !matches!(st, Type::UserType(_))
                 {
                     self.errors.push(AnalyzeError {
                         kind: AnalyzeErrorKind::MatchScrutineeType(st.clone()),
@@ -666,7 +706,7 @@ impl Analyzer {
                     }
                 }
                 // enum 網羅性チェック
-                if let Some(Type::UserEnum(ref enum_name)) = scr_ty
+                if let Some(Type::UserType(ref enum_name)) = scr_ty
                     && let Some(all_variants) = self.enums.get(enum_name).cloned()
                 {
                     let covered: Vec<String> = arms
@@ -708,6 +748,111 @@ impl Analyzer {
                 }
                 Some(first_ty)
             }
+            ExprKind::StructLiteral { name, fields, base } => {
+                if let Some(struct_fields) = self.structs.get(name).cloned() {
+                    // base がある場合、struct 型であることを確認
+                    if let Some(base_expr) = base
+                        && let Some(base_ty) = self.type_check_expr(base_expr)
+                        && base_ty != Type::UserType(name.clone())
+                    {
+                        self.errors.push(AnalyzeError {
+                            kind: AnalyzeErrorKind::TypeMismatch {
+                                context: "struct update base type mismatch",
+                                expected: Type::UserType(name.clone()),
+                                found: base_ty,
+                            },
+                        });
+                    }
+                    // 重複フィールドチェック
+                    let mut seen = Vec::new();
+                    for (field_name, value) in fields {
+                        if seen.contains(field_name) {
+                            self.errors.push(AnalyzeError {
+                                kind: AnalyzeErrorKind::DuplicateField {
+                                    struct_name: name.clone(),
+                                    field: field_name.clone(),
+                                },
+                            });
+                        }
+                        seen.push(field_name.clone());
+                        // フィールド名の存在チェックと型チェック
+                        if let Some(sf) = struct_fields.iter().find(|f| &f.name == field_name) {
+                            if let Some(val_ty) = self.type_check_expr(value)
+                                && !Self::types_compatible(&sf.ty, &val_ty)
+                            {
+                                self.errors.push(AnalyzeError {
+                                    kind: AnalyzeErrorKind::TypeMismatch {
+                                        context: "struct field type mismatch",
+                                        expected: sf.ty.clone(),
+                                        found: val_ty,
+                                    },
+                                });
+                            }
+                        } else {
+                            self.errors.push(AnalyzeError {
+                                kind: AnalyzeErrorKind::UndefinedField {
+                                    struct_name: name.clone(),
+                                    field: field_name.clone(),
+                                },
+                            });
+                        }
+                    }
+                    // base なしの場合、全フィールドが指定されているかチェック
+                    if base.is_none() {
+                        let missing: Vec<String> = struct_fields
+                            .iter()
+                            .filter(|f| !seen.contains(&f.name))
+                            .map(|f| f.name.clone())
+                            .collect();
+                        if !missing.is_empty() {
+                            self.errors.push(AnalyzeError {
+                                kind: AnalyzeErrorKind::MissingFields {
+                                    struct_name: name.clone(),
+                                    missing,
+                                },
+                            });
+                        }
+                    }
+                    Some(Type::UserType(name.clone()))
+                } else {
+                    self.errors.push(AnalyzeError {
+                        kind: AnalyzeErrorKind::UndefinedStruct(name.clone()),
+                    });
+                    None
+                }
+            }
+            ExprKind::FieldAccess { expr: inner, field } => {
+                if let Some(ty) = self.type_check_expr(inner) {
+                    if let Type::UserType(struct_name) = &ty {
+                        if let Some(struct_fields) = self.structs.get(struct_name).cloned() {
+                            if let Some(sf) = struct_fields.iter().find(|f| &f.name == field) {
+                                Some(sf.ty.clone())
+                            } else {
+                                self.errors.push(AnalyzeError {
+                                    kind: AnalyzeErrorKind::UndefinedField {
+                                        struct_name: struct_name.clone(),
+                                        field: field.clone(),
+                                    },
+                                });
+                                None
+                            }
+                        } else {
+                            // UserType だが struct ではない (enum)
+                            self.errors.push(AnalyzeError {
+                                kind: AnalyzeErrorKind::FieldAccessOnNonStruct(ty),
+                            });
+                            None
+                        }
+                    } else {
+                        self.errors.push(AnalyzeError {
+                            kind: AnalyzeErrorKind::FieldAccessOnNonStruct(ty),
+                        });
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
             ExprKind::EnumVariant { enum_name, variant } => {
                 if let Some(variants) = self.enums.get(enum_name) {
                     if !variants.contains(variant) {
@@ -719,7 +864,7 @@ impl Analyzer {
                         });
                         None
                     } else {
-                        Some(Type::UserEnum(enum_name.clone()))
+                        Some(Type::UserType(enum_name.clone()))
                     }
                 } else {
                     self.errors.push(AnalyzeError {
@@ -759,11 +904,12 @@ impl Analyzer {
     fn type_check_stmt(&mut self, stmt: &Stmt) {
         match &stmt.kind {
             StmtKind::Let { name, ty, value } => {
-                if let Type::UserEnum(enum_name) = ty
-                    && !self.enums.contains_key(enum_name)
+                if let Type::UserType(type_name) = ty
+                    && !self.enums.contains_key(type_name)
+                    && !self.structs.contains_key(type_name)
                 {
                     self.errors.push(AnalyzeError {
-                        kind: AnalyzeErrorKind::UnknownType(enum_name.clone()),
+                        kind: AnalyzeErrorKind::UnknownType(type_name.clone()),
                     });
                 }
                 if let Some(vt) = self.type_check_expr(value)

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,18 +7,21 @@ use crate::parser::ast::*;
 const INSTRUCTION_SIZE: u16 = 2;
 
 /// コード生成した値の所在
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum ValueLocation {
     /// 値はレジスタに格納されている
     InRegister(Register),
+    /// struct の値: 連続レジスタに格納
+    InRegisters(Vec<Register>),
     /// 値を生成しない式 (loop, 配列リテラルなど)
     Void,
 }
 
 impl ValueLocation {
-    fn register(self) -> Option<Register> {
+    fn register(&self) -> Option<Register> {
         match self {
-            ValueLocation::InRegister(r) => Some(r),
+            ValueLocation::InRegister(r) => Some(*r),
+            ValueLocation::InRegisters(regs) => regs.first().copied(),
             ValueLocation::Void => None,
         }
     }
@@ -42,6 +45,18 @@ enum ForwardRefKind {
     GlobalAddr(String),
 }
 
+/// ローカル変数のバインディング情報
+#[derive(Clone)]
+enum LocalBinding {
+    /// スカラー値 (u8, bool, enum)
+    Single(UserRegister),
+    /// struct 値: base レジスタと struct 名
+    Struct {
+        base_reg: UserRegister,
+        struct_name: String,
+    },
+}
+
 /// コード生成器
 ///
 /// AST を走査して CHIP-8 バイトコードを生成する。
@@ -61,10 +76,12 @@ pub struct CodeGen {
     sprite_sizes: HashMap<String, usize>,
     /// enum variant → u8 値
     enum_variant_values: HashMap<(String, String), u8>,
+    /// struct 定義 (名前 → フィールド定義リスト)
+    struct_defs: HashMap<String, Vec<StructField>>,
     /// レジスタ退避用の次のスロットアドレス
     next_save_slot: u16,
-    /// ローカル変数名 → 割り当て済みレジスタ
-    local_bindings: HashMap<String, UserRegister>,
+    /// ローカル変数名 → 割り当て済みバインディング
+    local_bindings: HashMap<String, LocalBinding>,
     /// 次に割り当て可能なレジスタ番号
     next_free_reg: u8,
     /// ローカル変数にバインド済みのレジスタ数 (一時レジスタのリセット基準)
@@ -91,6 +108,7 @@ impl CodeGen {
             resolved_addrs: HashMap::new(),
             sprite_sizes: HashMap::new(),
             enum_variant_values: HashMap::new(),
+            struct_defs: HashMap::new(),
             next_save_slot: 0x0A0,
             local_bindings: HashMap::new(),
             next_free_reg: 0,
@@ -105,13 +123,19 @@ impl CodeGen {
 
     /// プログラム全体をコード生成し、バイトコードを返す
     pub fn generate(&mut self, program: &Program) -> Vec<u8> {
-        // Pass 0: enum 定義を登録
+        // Pass 0: enum / struct 定義を登録
         for top in &program.top_levels {
-            if let TopLevel::EnumDef { name, variants, .. } = top {
-                for (i, variant) in variants.iter().enumerate() {
-                    self.enum_variant_values
-                        .insert((name.clone(), variant.clone()), i as u8);
+            match top {
+                TopLevel::EnumDef { name, variants, .. } => {
+                    for (i, variant) in variants.iter().enumerate() {
+                        self.enum_variant_values
+                            .insert((name.clone(), variant.clone()), i as u8);
+                    }
                 }
+                TopLevel::StructDef { name, fields, .. } => {
+                    self.struct_defs.insert(name.clone(), fields.clone());
+                }
+                _ => {}
             }
         }
 
@@ -161,8 +185,27 @@ impl CodeGen {
                 self.local_var_count = 0;
 
                 for param in params {
+                    if let Type::UserType(ref type_name) = param.ty
+                        && self.struct_defs.contains_key(type_name)
+                    {
+                        let base_reg = self.alloc_register();
+                        let count = self.struct_field_count(type_name);
+                        // 追加の連続レジスタを確保
+                        for _ in 1..count {
+                            self.alloc_register();
+                        }
+                        self.local_bindings.insert(
+                            param.name.clone(),
+                            LocalBinding::Struct {
+                                base_reg,
+                                struct_name: type_name.clone(),
+                            },
+                        );
+                        continue;
+                    }
                     let reg = self.alloc_register();
-                    self.local_bindings.insert(param.name.clone(), reg);
+                    self.local_bindings
+                        .insert(param.name.clone(), LocalBinding::Single(reg));
                 }
                 self.local_var_count = self.next_free_reg;
 
@@ -262,12 +305,89 @@ impl CodeGen {
         self.alloc_register()
     }
 
-    fn lookup_register(&self, name: &str) -> Option<UserRegister> {
-        self.local_bindings.get(name).copied()
+    fn lookup_binding(&self, name: &str) -> Option<&LocalBinding> {
+        self.local_bindings.get(name)
     }
 
     fn v0_is_bound(&self) -> bool {
-        self.local_bindings.values().any(|r| r.index() == 0)
+        self.local_bindings.values().any(|b| match b {
+            LocalBinding::Single(r) => r.index() == 0,
+            LocalBinding::Struct { base_reg, .. } => base_reg.index() == 0,
+        })
+    }
+
+    /// struct のフラット化フィールド数を計算
+    fn struct_field_count(&self, struct_name: &str) -> usize {
+        if let Some(fields) = self.struct_defs.get(struct_name) {
+            fields
+                .iter()
+                .map(|f| {
+                    if let Type::UserType(ref name) = f.ty
+                        && self.struct_defs.contains_key(name)
+                    {
+                        return self.struct_field_count(name);
+                    }
+                    1
+                })
+                .sum()
+        } else {
+            1
+        }
+    }
+
+    /// struct 内のフィールドのレジスタオフセットを計算
+    fn struct_field_offset(&self, struct_name: &str, field_name: &str) -> Option<usize> {
+        let fields = self.struct_defs.get(struct_name)?;
+        let mut offset = 0;
+        for f in fields {
+            if f.name == field_name {
+                return Some(offset);
+            }
+            if let Type::UserType(ref name) = f.ty
+                && self.struct_defs.contains_key(name)
+            {
+                offset += self.struct_field_count(name);
+                continue;
+            }
+            offset += 1;
+        }
+        None
+    }
+
+    /// struct のフィールドの型を取得
+    fn struct_field_type(&self, struct_name: &str, field_name: &str) -> Option<Type> {
+        let fields = self.struct_defs.get(struct_name)?;
+        fields
+            .iter()
+            .find(|f| f.name == field_name)
+            .map(|f| f.ty.clone())
+    }
+
+    /// 式から struct 名を推定
+    fn infer_struct_name(&self, expr: &Expr) -> Option<String> {
+        match &expr.kind {
+            ExprKind::Ident(name) => {
+                if let Some(LocalBinding::Struct { struct_name, .. }) = self.lookup_binding(name) {
+                    Some(struct_name.clone())
+                } else {
+                    None
+                }
+            }
+            ExprKind::StructLiteral { name, .. } => Some(name.clone()),
+            ExprKind::FieldAccess {
+                expr: inner, field, ..
+            } => {
+                let parent_name = self.infer_struct_name(inner)?;
+                if let Some(field_ty) = self.struct_field_type(&parent_name, field)
+                    && let Type::UserType(name) = field_ty
+                    && self.struct_defs.contains_key(&name)
+                {
+                    return Some(name);
+                }
+                None
+            }
+            _ => None,
+        }
     }
 
     fn emit_ld_i_global(&mut self, name: &str) {
@@ -404,8 +524,22 @@ impl CodeGen {
                 ValueLocation::InRegister(reg.into())
             }
             ExprKind::Ident(name) => {
-                if let Some(reg) = self.lookup_register(name) {
-                    ValueLocation::InRegister(reg.into())
+                if let Some(binding) = self.lookup_binding(name).cloned() {
+                    match binding {
+                        LocalBinding::Single(reg) => ValueLocation::InRegister(reg.into()),
+                        LocalBinding::Struct {
+                            base_reg,
+                            ref struct_name,
+                        } => {
+                            let count = self.struct_field_count(struct_name);
+                            let regs: Vec<Register> = (0..count)
+                                .map(|i| {
+                                    Register::from(UserRegister::new(base_reg.index() + i as u8))
+                                })
+                                .collect();
+                            ValueLocation::InRegisters(regs)
+                        }
+                    }
                 } else {
                     let reg = self.alloc_temp_register();
                     if self.data_offsets.contains_key(name) {
@@ -680,6 +814,127 @@ impl CodeGen {
                 self.emit_op(Opcode::LdImm(reg.into(), val));
                 ValueLocation::InRegister(reg.into())
             }
+            ExprKind::StructLiteral { name, fields, base } => {
+                let field_count = self.struct_field_count(name);
+                let struct_fields = self.struct_defs.get(name).cloned().unwrap_or_default();
+
+                // 結果用の連続レジスタを確保
+                let base_reg = self.alloc_temp_register();
+                for _ in 1..field_count {
+                    self.alloc_temp_register();
+                }
+                let result_regs: Vec<Register> = (0..field_count)
+                    .map(|i| UserRegister::new(base_reg.index() + i as u8).into())
+                    .collect();
+
+                // base がある場合、先にコピー
+                if let Some(base_expr) = base {
+                    let base_loc = self.codegen_expr(base_expr);
+                    if let ValueLocation::InRegisters(ref src_regs) = base_loc {
+                        for (i, &src) in src_regs.iter().enumerate() {
+                            if i < result_regs.len() && src != result_regs[i] {
+                                self.emit_op(Opcode::LdReg(result_regs[i], src));
+                            }
+                        }
+                    }
+                }
+
+                // 各フィールドの値を該当するレジスタに設定
+                for (field_name, value_expr) in fields {
+                    if let Some(offset) = self.struct_field_offset(name, field_name) {
+                        // フィールドが struct 型の場合
+                        let field_ty = struct_fields
+                            .iter()
+                            .find(|f| &f.name == field_name)
+                            .map(|f| &f.ty);
+                        if let Some(Type::UserType(sub_name)) = field_ty
+                            && self.struct_defs.contains_key(sub_name)
+                        {
+                            let val_loc = self.codegen_expr(value_expr);
+                            if let ValueLocation::InRegisters(ref src_regs) = val_loc {
+                                let sub_count = self.struct_field_count(sub_name);
+                                for i in 0..sub_count.min(src_regs.len()) {
+                                    if src_regs[i] != result_regs[offset + i] {
+                                        self.emit_op(Opcode::LdReg(
+                                            result_regs[offset + i],
+                                            src_regs[i],
+                                        ));
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                        // スカラーフィールド
+                        if let Some(val_reg) = self.codegen_expr(value_expr).register()
+                            && val_reg != result_regs[offset]
+                        {
+                            self.emit_op(Opcode::LdReg(result_regs[offset], val_reg));
+                        }
+                    }
+                }
+
+                ValueLocation::InRegisters(result_regs)
+            }
+            ExprKind::FieldAccess { expr: inner, field } => {
+                let inner_loc = self.codegen_expr(inner);
+                match inner_loc {
+                    ValueLocation::InRegisters(ref regs) => {
+                        // inner の型から struct 名を推定する必要がある
+                        // Ident の場合は local_bindings から取得
+                        let struct_name = self.infer_struct_name(inner);
+                        if let Some(ref sn) = struct_name
+                            && let Some(offset) = self.struct_field_offset(sn, field)
+                        {
+                            // フィールドが struct の場合、複数レジスタを返す
+                            if let Some(field_ty) = self.struct_field_type(sn, field)
+                                && let Type::UserType(ref sub_name) = field_ty
+                                && self.struct_defs.contains_key(sub_name)
+                            {
+                                let sub_count = self.struct_field_count(sub_name);
+                                let sub_regs: Vec<Register> =
+                                    (0..sub_count).map(|i| regs[offset + i]).collect();
+                                return ValueLocation::InRegisters(sub_regs);
+                            }
+                            if offset < regs.len() {
+                                return ValueLocation::InRegister(regs[offset]);
+                            }
+                        }
+                        ValueLocation::Void
+                    }
+                    _ => {
+                        // single register binding for struct (lookup from local bindings)
+                        if let ExprKind::Ident(name) = &inner.kind
+                            && let Some(LocalBinding::Struct {
+                                base_reg,
+                                struct_name,
+                            }) = self.lookup_binding(name).cloned()
+                        {
+                            let count = self.struct_field_count(&struct_name);
+                            let regs: Vec<Register> = (0..count)
+                                .map(|i| {
+                                    Register::from(UserRegister::new(base_reg.index() + i as u8))
+                                })
+                                .collect();
+                            if let Some(offset) = self.struct_field_offset(&struct_name, field) {
+                                // フィールドが struct 型かチェック
+                                if let Some(field_ty) = self.struct_field_type(&struct_name, field)
+                                    && let Type::UserType(ref sub_name) = field_ty
+                                    && self.struct_defs.contains_key(sub_name)
+                                {
+                                    let sub_count = self.struct_field_count(sub_name);
+                                    let sub_regs: Vec<Register> =
+                                        (0..sub_count).map(|i| regs[offset + i]).collect();
+                                    return ValueLocation::InRegisters(sub_regs);
+                                }
+                                if offset < regs.len() {
+                                    return ValueLocation::InRegister(regs[offset]);
+                                }
+                            }
+                        }
+                        ValueLocation::Void
+                    }
+                }
+            }
             ExprKind::ArrayLiteral(_) => ValueLocation::Void,
             ExprKind::Index { array, index } => {
                 if let ExprKind::Ident(name) = &array.kind
@@ -855,24 +1110,57 @@ impl CodeGen {
 
     fn codegen_stmt(&mut self, stmt: &Stmt) {
         match &stmt.kind {
-            StmtKind::Let { name, value, .. } => {
-                if let Some(val_reg) = self.codegen_expr(value).register() {
+            StmtKind::Let { name, ty, value } => {
+                let val_loc = self.codegen_expr(value);
+                // struct 型の let: 連続レジスタをバインド
+                if let Type::UserType(type_name) = ty
+                    && self.struct_defs.contains_key(type_name)
+                    && let ValueLocation::InRegisters(ref regs) = val_loc
+                {
+                    let count = self.struct_field_count(type_name);
+                    self.next_free_reg = self.local_var_count;
+                    let base_reg = self.alloc_register();
+                    for _ in 1..count {
+                        self.alloc_register();
+                    }
+                    // 値をコピー
+                    for (i, &src_reg) in regs.iter().enumerate() {
+                        let dst: Register = UserRegister::new(base_reg.index() + i as u8).into();
+                        if src_reg != dst {
+                            self.emit_op(Opcode::LdReg(dst, src_reg));
+                        }
+                    }
+                    self.local_bindings.insert(
+                        name.clone(),
+                        LocalBinding::Struct {
+                            base_reg,
+                            struct_name: type_name.clone(),
+                        },
+                    );
+                    self.local_var_count = self.next_free_reg;
+                    return;
+                }
+                // スカラー型の let
+                if let Some(val_reg) = val_loc.register() {
                     self.next_free_reg = self.local_var_count;
                     let reg = self.alloc_register();
                     if val_reg != Register::from(reg) {
                         self.emit_op(Opcode::LdReg(reg.into(), val_reg));
                     }
-                    self.local_bindings.insert(name.clone(), reg);
+                    self.local_bindings
+                        .insert(name.clone(), LocalBinding::Single(reg));
                     self.local_var_count = self.next_free_reg;
                     return;
                 }
             }
             StmtKind::Assign { name, value } => {
                 if let Some(val_reg) = self.codegen_expr(value).register()
-                    && let Some(&target_reg) = self.local_bindings.get(name)
-                    && val_reg != Register::from(target_reg)
+                    && let Some(LocalBinding::Single(target_reg)) = self.local_bindings.get(name)
                 {
-                    self.emit_op(Opcode::LdReg(target_reg.into(), val_reg));
+                    let target: Register = (*target_reg).into();
+                    if val_reg != target {
+                        self.emit_op(Opcode::LdReg(target, val_reg));
+                    }
                 }
             }
             StmtKind::Expr(expr) => {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -275,6 +275,7 @@ impl Lexer {
             "false" => TokenKind::False,
             "match" => TokenKind::Match,
             "enum" => TokenKind::Enum,
+            "struct" => TokenKind::Struct,
             _ => TokenKind::Ident(s),
         };
 
@@ -296,6 +297,14 @@ impl Lexer {
             '}' => TokenKind::RBrace,
             '[' => TokenKind::LBracket,
             ']' => TokenKind::RBracket,
+            '.' => {
+                if self.peek() == Some('.') {
+                    self.advance();
+                    TokenKind::DotDot
+                } else {
+                    TokenKind::Dot
+                }
+            }
             ',' => TokenKind::Comma,
             ';' => TokenKind::Semicolon,
             ':' => {

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -20,6 +20,7 @@ pub enum TokenKind {
     False,
     Match,
     Enum,
+    Struct,
 
     // リテラル
     IntLiteral(u64),
@@ -58,6 +59,8 @@ pub enum TokenKind {
     FatArrow,   // =>
     ColonColon, // ::
     Pipe,       // |>
+    Dot,        // .
+    DotDot,     // ..
 
     // 特殊
     Eof,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -8,7 +8,7 @@ pub enum Type {
     Unit,
     Array(Box<Type>, usize),
     Sprite(usize),
-    UserEnum(String),
+    UserType(String),
 }
 
 /// 二項演算子
@@ -91,6 +91,15 @@ pub enum ExprKind {
         enum_name: String,
         variant: String,
     },
+    StructLiteral {
+        name: String,
+        fields: Vec<(String, Expr)>,
+        base: Option<Box<Expr>>,
+    },
+    FieldAccess {
+        expr: Box<Expr>,
+        field: String,
+    },
 }
 
 /// match 式のアーム
@@ -114,6 +123,13 @@ pub enum StmtKind {
     Expr(Expr),
     Return(Option<Expr>),
     Break,
+}
+
+/// struct のフィールド定義
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructField {
+    pub name: String,
+    pub ty: Type,
 }
 
 /// 関数の引数
@@ -142,6 +158,11 @@ pub enum TopLevel {
     EnumDef {
         name: String,
         variants: Vec<String>,
+        span: Span,
+    },
+    StructDef {
+        name: String,
+        fields: Vec<StructField>,
         span: Span,
     },
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -70,6 +70,14 @@ impl Parser {
         &self.tokens[self.pos].kind
     }
 
+    fn peek_at(&self, offset: usize) -> &TokenKind {
+        if self.pos + offset < self.tokens.len() {
+            &self.tokens[self.pos + offset].kind
+        } else {
+            &TokenKind::Eof
+        }
+    }
+
     fn current_span(&self) -> Span {
         self.tokens[self.pos].span
     }
@@ -125,9 +133,10 @@ impl Parser {
             TokenKind::Fn => self.parse_fn_def(),
             TokenKind::Let => self.parse_let_def(),
             TokenKind::Enum => self.parse_enum_def(),
+            TokenKind::Struct => self.parse_struct_def(),
             _ => Err(ParseError {
                 kind: ParseErrorKind::UnexpectedToken {
-                    expected: "'fn', 'let', or 'enum'".to_string(),
+                    expected: "'fn', 'let', 'enum', or 'struct'".to_string(),
                     found: self.peek().clone(),
                 },
                 span: self.current_span(),
@@ -211,6 +220,28 @@ impl Parser {
         })
     }
 
+    fn parse_struct_def(&mut self) -> Result<TopLevel, ParseError> {
+        let span = self.current_span();
+        self.expect(&TokenKind::Struct)?;
+        let (name, _) = self.expect_ident()?;
+        self.expect(&TokenKind::LBrace)?;
+        let mut fields = Vec::new();
+        while self.peek() != &TokenKind::RBrace {
+            let (field_name, _) = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let ty = self.parse_type()?;
+            fields.push(StructField {
+                name: field_name,
+                ty,
+            });
+            if self.peek() == &TokenKind::Comma {
+                self.advance();
+            }
+        }
+        self.expect(&TokenKind::RBrace)?;
+        Ok(TopLevel::StructDef { name, fields, span })
+    }
+
     // ---- 型 ----
 
     fn parse_type(&mut self) -> Result<Type, ParseError> {
@@ -227,7 +258,7 @@ impl Parser {
                         self.expect(&TokenKind::RParen)?;
                         Ok(Type::Sprite(size as usize))
                     }
-                    _ => Ok(Type::UserEnum(name)),
+                    _ => Ok(Type::UserType(name)),
                 }
             }
             TokenKind::LParen => {
@@ -435,6 +466,17 @@ impl Parser {
                     },
                     span,
                 };
+            } else if self.peek() == &TokenKind::Dot {
+                let span = expr.span;
+                self.advance();
+                let (field, _) = self.expect_ident()?;
+                expr = Expr {
+                    kind: ExprKind::FieldAccess {
+                        expr: Box::new(expr),
+                        field,
+                    },
+                    span,
+                };
             } else {
                 break;
             }
@@ -479,6 +521,21 @@ impl Parser {
                         },
                         span,
                     });
+                }
+                // struct リテラル: Name { field: value, ... }
+                // 先読みで { Ident : ... } or { .. } or { } パターンを確認
+                if self.peek() == &TokenKind::LBrace {
+                    let is_struct_literal = match self.peek_at(1) {
+                        TokenKind::DotDot => true, // Name { ..base }
+                        TokenKind::Ident(_) => {
+                            // Name { field: ... } なら struct リテラル
+                            matches!(self.peek_at(2), TokenKind::Colon)
+                        }
+                        _ => false,
+                    };
+                    if is_struct_literal {
+                        return self.parse_struct_literal(name, span);
+                    }
                 }
                 // 関数呼び出し
                 if self.peek() == &TokenKind::LParen {
@@ -544,6 +601,35 @@ impl Parser {
                 span,
             }),
         }
+    }
+
+    fn parse_struct_literal(&mut self, name: String, span: Span) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::LBrace)?;
+        let mut fields = Vec::new();
+        let mut base = None;
+        while self.peek() != &TokenKind::RBrace {
+            // struct update 構文: ..base
+            if self.peek() == &TokenKind::DotDot {
+                self.advance();
+                base = Some(Box::new(self.parse_expr()?));
+                if self.peek() == &TokenKind::Comma {
+                    self.advance();
+                }
+                continue;
+            }
+            let (field_name, _) = self.expect_ident()?;
+            self.expect(&TokenKind::Colon)?;
+            let value = self.parse_expr()?;
+            fields.push((field_name, value));
+            if self.peek() == &TokenKind::Comma {
+                self.advance();
+            }
+        }
+        self.expect(&TokenKind::RBrace)?;
+        Ok(Expr {
+            kind: ExprKind::StructLiteral { name, fields, base },
+            span,
+        })
     }
 
     fn parse_call_args(&mut self) -> Result<Vec<Expr>, ParseError> {

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -504,3 +504,77 @@ fn test_random_enum_wrong_arg_count() {
         },
     );
 }
+
+#[test]
+fn test_struct_basic() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos { Pos { x: 1, y: 2 } }",
+    );
+}
+
+#[test]
+fn test_struct_field_access() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> u8 {
+            let p: Pos = Pos { x: 10, y: 20 };
+            p.x
+         }",
+    );
+}
+
+#[test]
+fn test_struct_undefined_field() {
+    analyze_err_kind(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos { Pos { x: 1, z: 2 } }",
+        AnalyzeErrorKind::UndefinedField {
+            struct_name: "Pos".to_string(),
+            field: "z".to_string(),
+        },
+    );
+}
+
+#[test]
+fn test_struct_missing_fields() {
+    analyze_err_matches(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos { Pos { x: 1 } }",
+        |k| matches!(k, AnalyzeErrorKind::MissingFields { .. }),
+    );
+}
+
+#[test]
+fn test_struct_field_access_on_non_struct() {
+    analyze_err_matches(
+        "fn main() -> u8 {
+            let x: u8 = 1;
+            x.field
+         }",
+        |k| matches!(k, AnalyzeErrorKind::FieldAccessOnNonStruct(_)),
+    );
+}
+
+#[test]
+fn test_struct_update_syntax() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos {
+            let p: Pos = Pos { x: 1, y: 2 };
+            Pos { ..p, x: 10 }
+         }",
+    );
+}
+
+#[test]
+fn test_struct_as_param_and_return() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn get_x(p: Pos) -> u8 { p.x }
+         fn main() -> u8 {
+            let p: Pos = Pos { x: 5, y: 10 };
+            get_x(p)
+         }",
+    );
+}

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -365,3 +365,22 @@ fn test_non_tail_recursion_generates_call() {
         "expected 2 CALL instructions (non-tail recursion)"
     );
 }
+
+#[test]
+fn test_struct_literal_and_field_access() {
+    // struct リテラルとフィールドアクセスがコンパイルできること
+    let bytes = compile(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> u8 {
+            let p: Pos = Pos { x: 10, y: 20 };
+            p.x
+         }",
+    );
+    // コンパイルが成功し、適切なバイトコードが生成されること
+    assert!(bytes.len() >= 4);
+    // LD 命令 (6XKK) が含まれること (10 と 20 のロード)
+    let has_ld_10 = bytes.chunks(2).any(|c| (c[0] & 0xF0) == 0x60 && c[1] == 10);
+    let has_ld_20 = bytes.chunks(2).any(|c| (c[0] & 0xF0) == 0x60 && c[1] == 20);
+    assert!(has_ld_10, "expected LD with value 10");
+    assert!(has_ld_20, "expected LD with value 20");
+}

--- a/tests/lexer_tests.rs
+++ b/tests/lexer_tests.rs
@@ -310,3 +310,16 @@ fn test_pipe_operator() {
     let ks = kinds("x |> f()");
     assert!(ks.contains(&TokenKind::Pipe));
 }
+
+#[test]
+fn test_struct_keyword_and_dot() {
+    let ks = kinds("struct Pos { x: u8 }");
+    assert!(ks.contains(&TokenKind::Struct));
+    assert!(ks.contains(&TokenKind::Colon));
+
+    let ks2 = kinds("p.x");
+    assert!(ks2.contains(&TokenKind::Dot));
+
+    let ks3 = kinds("Pos { ..base }");
+    assert!(ks3.contains(&TokenKind::DotDot));
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -555,3 +555,106 @@ fn test_random_enum_parses_as_builtin_call() {
         _ => panic!("expected FnDef"),
     }
 }
+
+#[test]
+fn test_struct_def() {
+    let prog = parse("struct Pos { x: u8, y: u8 }");
+    assert_eq!(prog.top_levels.len(), 1);
+    match &prog.top_levels[0] {
+        TopLevel::StructDef { name, fields, .. } => {
+            assert_eq!(name, "Pos");
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].name, "x");
+            assert_eq!(fields[0].ty, Type::U8);
+            assert_eq!(fields[1].name, "y");
+            assert_eq!(fields[1].ty, Type::U8);
+        }
+        _ => panic!("expected StructDef"),
+    }
+}
+
+#[test]
+fn test_struct_literal() {
+    let prog = parse(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos { Pos { x: 10, y: 20 } }",
+    );
+    match &prog.top_levels[1] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(tail), ..
+            } = &body.kind
+            {
+                if let ExprKind::StructLiteral { name, fields, base } = &tail.kind {
+                    assert_eq!(name, "Pos");
+                    assert_eq!(fields.len(), 2);
+                    assert_eq!(fields[0].0, "x");
+                    assert_eq!(fields[1].0, "y");
+                    assert!(base.is_none());
+                } else {
+                    panic!("expected StructLiteral, got {:?}", tail.kind);
+                }
+            } else {
+                panic!("expected Block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_field_access() {
+    let prog = parse(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> u8 {
+            let p: Pos = Pos { x: 1, y: 2 };
+            p.x
+         }",
+    );
+    match &prog.top_levels[1] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(tail), ..
+            } = &body.kind
+            {
+                assert!(matches!(
+                    &tail.kind,
+                    ExprKind::FieldAccess { field, .. } if field == "x"
+                ));
+            } else {
+                panic!("expected Block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn test_struct_update_syntax() {
+    let prog = parse(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> Pos {
+            let p: Pos = Pos { x: 1, y: 2 };
+            Pos { ..p, x: 10 }
+         }",
+    );
+    match &prog.top_levels[1] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block {
+                expr: Some(tail), ..
+            } = &body.kind
+            {
+                if let ExprKind::StructLiteral { base, fields, .. } = &tail.kind {
+                    assert!(base.is_some());
+                    assert_eq!(fields.len(), 1);
+                    assert_eq!(fields[0].0, "x");
+                } else {
+                    panic!("expected StructLiteral");
+                }
+            } else {
+                panic!("expected Block with tail expr");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}


### PR DESCRIPTION
## Summary
- struct 定義・リテラル・フィールドアクセス (ドット記法)・struct update 構文を全レイヤで実装
- フィールドは連続レジスタにフラット化して配置 (ネスト struct 対応)
- `Type::UserEnum` → `Type::UserType` にリネームし enum/struct を統一的に扱う
- 先読み (lookahead) で `Name { field: value }` と `if x { ... }` を区別

## Test plan
- [x] Lexer: `struct`, `.`, `..` トークンのテスト
- [x] Parser: struct 定義、リテラル、フィールドアクセス、update 構文のパース
- [x] Analyzer: 正常系 (基本、フィールドアクセス、update、引数/戻り値)
- [x] Analyzer: エラー系 (未定義フィールド、不足フィールド、非struct へのアクセス)
- [x] CodeGen: struct リテラルとフィールドアクセスのコンパイル
- [x] 既存テスト全件通過 (140 tests)
- [x] `cargo test && cargo clippy && cargo fmt --check` 通過

Closes #25
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)