### PR TITLE
feat: enum/struct の等値比較 (==, !=) を実装 (#29)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -549,6 +549,39 @@ impl CodeGen {
                 }
             }
             ExprKind::BinaryOp { op, lhs, rhs } => {
+                // struct の等値比較: フィールドごとに比較
+                if matches!(op, BinOp::Eq | BinOp::NotEq) {
+                    let lhs_loc = self.codegen_expr(lhs);
+                    let rhs_loc = self.codegen_expr(rhs);
+                    if let (
+                        ValueLocation::InRegisters(lhs_regs),
+                        ValueLocation::InRegisters(rhs_regs),
+                    ) = (&lhs_loc, &rhs_loc)
+                    {
+                        return self.codegen_struct_equality(lhs_regs, rhs_regs, *op == BinOp::Eq);
+                    }
+                    // struct でない場合、スカラー比較にフォールスルー
+                    let Some(lhs_reg) = lhs_loc.register() else {
+                        return ValueLocation::Void;
+                    };
+                    let Some(rhs_reg) = rhs_loc.register() else {
+                        return ValueLocation::Void;
+                    };
+                    let res = self.alloc_temp_register();
+                    if *op == BinOp::Eq {
+                        self.emit_op(Opcode::LdImm(res.into(), 0));
+                        self.emit_op(Opcode::SeReg(lhs_reg, rhs_reg));
+                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+                        self.emit_op(Opcode::LdImm(res.into(), 1));
+                    } else {
+                        self.emit_op(Opcode::LdImm(res.into(), 0));
+                        self.emit_op(Opcode::SneReg(lhs_reg, rhs_reg));
+                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+                        self.emit_op(Opcode::LdImm(res.into(), 1));
+                    }
+                    return ValueLocation::InRegister(res.into());
+                }
+
                 let Some(lhs_reg) = self.codegen_expr(lhs).register() else {
                     return ValueLocation::Void;
                 };
@@ -564,22 +597,8 @@ impl CodeGen {
                         self.emit_op(Opcode::Sub(lhs_reg, rhs_reg));
                     }
                     BinOp::Mul | BinOp::Div | BinOp::Mod => {}
-                    BinOp::Eq => {
-                        let res = self.alloc_temp_register();
-                        self.emit_op(Opcode::LdImm(res.into(), 0));
-                        self.emit_op(Opcode::SeReg(lhs_reg, rhs_reg));
-                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
-                        self.emit_op(Opcode::LdImm(res.into(), 1));
-                        return ValueLocation::InRegister(res.into());
-                    }
-                    BinOp::NotEq => {
-                        let res = self.alloc_temp_register();
-                        self.emit_op(Opcode::LdImm(res.into(), 0));
-                        self.emit_op(Opcode::SneReg(lhs_reg, rhs_reg));
-                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
-                        self.emit_op(Opcode::LdImm(res.into(), 1));
-                        return ValueLocation::InRegister(res.into());
-                    }
+                    // Eq/NotEq は上で早期リターン済み
+                    BinOp::Eq | BinOp::NotEq => unreachable!(),
                     BinOp::Lt => {
                         let res = self.alloc_temp_register();
                         let tmp = self.alloc_temp_register();
@@ -966,6 +985,49 @@ impl CodeGen {
     }
 
     /// 組み込み関数のコード生成 (exhaustive match で全バリアントをカバー)
+    /// struct の等値比較: フィールドごとに比較し AND (eq) / OR (neq) で集約
+    fn codegen_struct_equality(
+        &mut self,
+        lhs_regs: &[Register],
+        rhs_regs: &[Register],
+        is_eq: bool,
+    ) -> ValueLocation {
+        let res = self.alloc_temp_register();
+
+        if lhs_regs.is_empty() {
+            // 空 struct: 常に等しい
+            self.emit_op(Opcode::LdImm(res.into(), if is_eq { 1 } else { 0 }));
+            return ValueLocation::InRegister(res.into());
+        }
+
+        // 最初のフィールド比較で結果を初期化
+        self.emit_op(Opcode::LdImm(res.into(), 0));
+        self.emit_op(Opcode::SeReg(lhs_regs[0], rhs_regs[0]));
+        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+        self.emit_op(Opcode::LdImm(res.into(), 1));
+        // res = 1 if lhs[0] == rhs[0], 0 otherwise
+
+        // 残りのフィールドについて AND で集約
+        for i in 1..lhs_regs.len().min(rhs_regs.len()) {
+            let tmp = self.alloc_temp_register();
+            self.emit_op(Opcode::LdImm(tmp.into(), 0));
+            self.emit_op(Opcode::SeReg(lhs_regs[i], rhs_regs[i]));
+            self.emit_op(Opcode::Jp(self.skip_next_addr()));
+            self.emit_op(Opcode::LdImm(tmp.into(), 1));
+            // res &= tmp (AND)
+            self.emit_op(Opcode::And(res.into(), tmp.into()));
+        }
+
+        // is_eq=false (NotEq) なら結果を反転: res = res XOR 1
+        if !is_eq {
+            let one = self.alloc_temp_register();
+            self.emit_op(Opcode::LdImm(one.into(), 1));
+            self.emit_op(Opcode::Xor(res.into(), one.into()));
+        }
+
+        ValueLocation::InRegister(res.into())
+    }
+
     fn codegen_builtin_call(&mut self, builtin: BuiltinFunction, args: &[Expr]) -> ValueLocation {
         // draw は args[0] をスプライト名参照として扱い、評価しない
         let is_draw = builtin == BuiltinFunction::Draw;

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -578,3 +578,38 @@ fn test_struct_as_param_and_return() {
          }",
     );
 }
+
+#[test]
+fn test_enum_equality() {
+    analyze_ok(
+        "enum Dir { Up, Down }
+         fn main() -> bool {
+            let d: Dir = Dir::Up;
+            d == Dir::Up
+         }",
+    );
+}
+
+#[test]
+fn test_struct_equality() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> bool {
+            let a: Pos = Pos { x: 1, y: 2 };
+            let b: Pos = Pos { x: 1, y: 2 };
+            a == b
+         }",
+    );
+}
+
+#[test]
+fn test_struct_inequality() {
+    analyze_ok(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> bool {
+            let a: Pos = Pos { x: 1, y: 2 };
+            let b: Pos = Pos { x: 3, y: 2 };
+            a != b
+         }",
+    );
+}

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -384,3 +384,35 @@ fn test_struct_literal_and_field_access() {
     assert!(has_ld_10, "expected LD with value 10");
     assert!(has_ld_20, "expected LD with value 20");
 }
+
+#[test]
+fn test_enum_equality_compiles() {
+    let bytes = compile(
+        "enum Dir { Up, Down }
+         fn main() -> bool {
+            let d: Dir = Dir::Up;
+            d == Dir::Down
+         }",
+    );
+    // SE (5XY0) 命令が含まれること (等値比較)
+    let has_se = bytes.chunks(2).any(|c| (c[0] & 0xF0) == 0x50);
+    assert!(has_se, "expected SE instruction for enum equality");
+}
+
+#[test]
+fn test_struct_equality_compiles() {
+    let bytes = compile(
+        "struct Pos { x: u8, y: u8 }
+         fn main() -> bool {
+            let a: Pos = Pos { x: 1, y: 2 };
+            let b: Pos = Pos { x: 1, y: 2 };
+            a == b
+         }",
+    );
+    // SE (5XY0) が2つ以上含まれること (フィールドごとの比較)
+    let se_count = bytes.chunks(2).filter(|c| (c[0] & 0xF0) == 0x50).count();
+    assert!(
+        se_count >= 2,
+        "expected at least 2 SE instructions for struct equality (field-by-field)"
+    );
+}


### PR DESCRIPTION
## Summary
- enum の `==` / `!=`: 内部 u8 表現なので既存の比較がそのまま動作
- struct の `==` / `!=`: フィールドごとに SE 比較し、結果を AND で集約
- `!=` は `==` の結果を XOR 1 で反転
- `BinaryOp::Eq/NotEq` を早期に struct 判定し、スカラー/struct で分岐

## Test plan
- [x] Analyzer: enum 等値比較が型チェック通過
- [x] Analyzer: struct 等値比較・不等値比較が型チェック通過
- [x] CodeGen: enum 比較で SE 命令が生成される
- [x] CodeGen: struct 比較でフィールド数分の SE 命令が生成される
- [x] 既存テスト全件通過 (145 tests)
- [x] `cargo test && cargo clippy && cargo fmt --check` 通過

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)