### PR TITLE
feat: #6,#8,#9,#10,#40 一括対応

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::parser::ast::*;
 
@@ -106,6 +106,8 @@ pub enum AnalyzeErrorKind {
     DuplicateField { struct_name: String, field: String },
     /// フィールドアクセスの対象が struct でない
     FieldAccessOnNonStruct(Type),
+    /// イミュータブル変数への代入
+    ImmutableAssignment(String),
 }
 
 /// 意味解析エラー
@@ -239,6 +241,9 @@ impl std::fmt::Display for AnalyzeError {
             AnalyzeErrorKind::FieldAccessOnNonStruct(ty) => {
                 write!(f, "field access on non-struct type: {ty:?}")
             }
+            AnalyzeErrorKind::ImmutableAssignment(name) => {
+                write!(f, "cannot assign to immutable variable '{name}'")
+            }
         }
     }
 }
@@ -254,6 +259,8 @@ struct FnSig {
 pub struct Analyzer {
     /// グローバル変数の型
     globals: HashMap<String, Type>,
+    /// ミュータブルなグローバル変数の名前
+    mutable_globals: HashSet<String>,
     /// ユーザー定義関数のシグネチャ
     functions: HashMap<String, FnSig>,
     /// ユーザー定義 enum (名前 → variant リスト)
@@ -274,6 +281,7 @@ impl Analyzer {
     pub fn new() -> Self {
         Self {
             globals: HashMap::new(),
+            mutable_globals: HashSet::new(),
             functions: HashMap::new(),
             enums: HashMap::new(),
             structs: HashMap::new(),
@@ -288,8 +296,13 @@ impl Analyzer {
         // Pass 1: 全トップレベル定義を登録
         for top in &program.top_levels {
             match top {
-                TopLevel::LetDef { name, ty, .. } => {
+                TopLevel::LetDef {
+                    name, ty, mutable, ..
+                } => {
                     self.globals.insert(name.clone(), ty.clone());
+                    if *mutable {
+                        self.mutable_globals.insert(name.clone());
+                    }
                 }
                 TopLevel::FnDef {
                     name,
@@ -940,6 +953,14 @@ impl Analyzer {
             StmtKind::Assign { name, value } => {
                 let var_ty = self.lookup_var(name);
                 let val_ty = self.type_check_expr(value);
+                // グローバル変数への代入は mutable でなければエラー
+                let is_global = self.globals.contains_key(name)
+                    && !self.locals.iter().any(|s| s.contains_key(name));
+                if is_global && !self.mutable_globals.contains(name) {
+                    self.errors.push(AnalyzeError {
+                        kind: AnalyzeErrorKind::ImmutableAssignment(name.clone()),
+                    });
+                }
                 match (var_ty, val_ty) {
                     (None, _) => {
                         self.errors.push(AnalyzeError {
@@ -957,6 +978,43 @@ impl Analyzer {
                         }
                     }
                     _ => {}
+                }
+            }
+            StmtKind::IndexAssign {
+                array,
+                index,
+                value,
+            } => {
+                let arr_ty = self.lookup_var(array);
+                // 配列型チェック
+                if let Some(ref ty) = arr_ty {
+                    if !matches!(ty, Type::Array { .. }) {
+                        self.errors.push(AnalyzeError {
+                            kind: AnalyzeErrorKind::CannotIndex(ty.clone()),
+                        });
+                    }
+                } else {
+                    self.errors.push(AnalyzeError {
+                        kind: AnalyzeErrorKind::UndefinedVariable(array.clone()),
+                    });
+                }
+                // インデックスは u8
+                if let Some(idx_ty) = self.type_check_expr(index)
+                    && idx_ty != Type::U8
+                {
+                    self.errors.push(AnalyzeError {
+                        kind: AnalyzeErrorKind::ArrayIndexNotU8(idx_ty),
+                    });
+                }
+                // 値の型チェック
+                self.type_check_expr(value);
+                // mutable チェック
+                let is_global = self.globals.contains_key(array)
+                    && !self.locals.iter().any(|s| s.contains_key(array));
+                if is_global && !self.mutable_globals.contains(array) {
+                    self.errors.push(AnalyzeError {
+                        kind: AnalyzeErrorKind::ImmutableAssignment(array.clone()),
+                    });
                 }
             }
             StmtKind::Expr(expr) => {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::chip8::{Addr, ByteOffset, Opcode, Register, SpriteHeight, UserRegister};
 use crate::parser::ast::*;
@@ -73,6 +73,8 @@ pub struct CodeGen {
     sprite_sizes: HashMap<String, usize>,
     /// enum variant → u8 値
     enum_variant_values: HashMap<(String, String), u8>,
+    /// ミュータブルグローバル変数
+    mutable_globals: HashSet<String>,
     /// struct 定義 (名前 → フィールド定義リスト)
     struct_defs: HashMap<String, Vec<StructField>>,
     /// 関数の戻り値型 (struct 戻り値のメモリ化に使用)
@@ -107,6 +109,7 @@ impl CodeGen {
             resolved_addrs: HashMap::new(),
             sprite_sizes: HashMap::new(),
             enum_variant_values: HashMap::new(),
+            mutable_globals: HashSet::new(),
             struct_defs: HashMap::new(),
             fn_return_types: HashMap::new(),
             next_save_slot: 0x0A0,
@@ -142,9 +145,16 @@ impl CodeGen {
         // Pass 1: グローバル定数・スプライトをデータとして記録
         for top in &program.top_levels {
             if let TopLevel::LetDef {
-                name, ty, value, ..
+                name,
+                ty,
+                value,
+                mutable,
+                ..
             } = top
             {
+                if *mutable {
+                    self.mutable_globals.insert(name.clone());
+                }
                 let data_offset = self.data.len();
                 match &value.kind {
                     ExprKind::ArrayLiteral(elems) => {
@@ -461,6 +471,28 @@ impl CodeGen {
         }
     }
 
+    fn emit_global_write(&mut self, name: &str, src_reg: Register) {
+        if src_reg == Register::V0 {
+            self.emit_ld_i_global(name);
+            self.emit_op(Opcode::LdIVx(Register::V0));
+        } else if self.v0_is_bound() {
+            // V0 を退避して値を書き込み
+            self.emit_op(Opcode::Xor(src_reg, Register::V0));
+            self.emit_op(Opcode::Xor(Register::V0, src_reg));
+            self.emit_op(Opcode::Xor(src_reg, Register::V0));
+            self.emit_ld_i_global(name);
+            self.emit_op(Opcode::LdIVx(Register::V0));
+            // V0 を復帰
+            self.emit_op(Opcode::Xor(src_reg, Register::V0));
+            self.emit_op(Opcode::Xor(Register::V0, src_reg));
+            self.emit_op(Opcode::Xor(src_reg, Register::V0));
+        } else {
+            self.emit_op(Opcode::LdReg(Register::V0, src_reg));
+            self.emit_ld_i_global(name);
+            self.emit_op(Opcode::LdIVx(Register::V0));
+        }
+    }
+
     /// メモリスロットを割り当て、開始アドレスを返す
     fn alloc_mem_slot(&mut self, size: u16) -> u16 {
         let addr = self.next_save_slot;
@@ -582,6 +614,19 @@ impl CodeGen {
                 let then_loc = self.codegen_expr_tail(then_block);
 
                 if let Some(else_block) = else_block {
+                    // then ブランチの InMemory → V0..V(n-1) にロード
+                    let then_is_memory = matches!(&then_loc, ValueLocation::InMemory { .. });
+                    if let ValueLocation::InMemory {
+                        addr,
+                        ref struct_name,
+                    } = then_loc
+                    {
+                        let count = self.struct_field_count(struct_name);
+                        self.emit_op(Opcode::LdI(Addr::new(addr)));
+                        let last = UserRegister::new(count as u8 - 1);
+                        self.emit_op(Opcode::LdVxI(last.into()));
+                    }
+
                     let jp_end_offset = self.emit_placeholder();
 
                     let else_addr = self.current_addr();
@@ -589,10 +634,26 @@ impl CodeGen {
 
                     let else_loc = self.codegen_expr_tail(else_block);
 
+                    // else ブランチの InMemory → V0..V(n-1) にロード
+                    let else_is_memory = matches!(&else_loc, ValueLocation::InMemory { .. });
+                    if let ValueLocation::InMemory {
+                        addr,
+                        ref struct_name,
+                    } = else_loc
+                    {
+                        let count = self.struct_field_count(struct_name);
+                        self.emit_op(Opcode::LdI(Addr::new(addr)));
+                        let last = UserRegister::new(count as u8 - 1);
+                        self.emit_op(Opcode::LdVxI(last.into()));
+                    }
+
                     let end_addr = self.current_addr();
                     self.patch_at(jp_end_offset, Opcode::Jp(end_addr));
 
                     match (then_loc, else_loc) {
+                        _ if then_is_memory || else_is_memory => {
+                            ValueLocation::InRegister(Register::V0)
+                        }
                         (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         (ValueLocation::InRegister(r), _) => ValueLocation::InRegister(r),
                         _ => ValueLocation::Void,
@@ -715,7 +776,64 @@ impl CodeGen {
                     BinOp::Sub => {
                         self.emit_op(Opcode::Sub(lhs_reg, rhs_reg));
                     }
-                    BinOp::Mul | BinOp::Div | BinOp::Mod => {}
+                    BinOp::Mul => {
+                        // ソフトウェア乗算: result += lhs を rhs 回繰り返す
+                        let result = self.alloc_temp_register();
+                        let counter = self.alloc_temp_register();
+                        let one = self.alloc_temp_register();
+                        self.emit_op(Opcode::LdImm(result.into(), 0));
+                        self.emit_op(Opcode::LdReg(counter.into(), rhs_reg));
+                        self.emit_op(Opcode::LdImm(one.into(), 1));
+                        let loop_addr = self.current_addr();
+                        // counter == 0 なら終了
+                        self.emit_op(Opcode::SeImm(counter.into(), 0));
+                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+                        let jp_break = self.emit_placeholder();
+                        self.emit_op(Opcode::Add(result.into(), lhs_reg));
+                        self.emit_op(Opcode::Sub(counter.into(), one.into()));
+                        self.emit_op(Opcode::Jp(loop_addr));
+                        let break_addr = self.current_addr();
+                        self.patch_at(jp_break, Opcode::Jp(break_addr));
+                        return ValueLocation::InRegister(result.into());
+                    }
+                    BinOp::Div => {
+                        // ソフトウェア除算: lhs から rhs を引ける回数を数える
+                        let quotient = self.alloc_temp_register();
+                        let tmp = self.alloc_temp_register();
+                        self.emit_op(Opcode::LdImm(quotient.into(), 0));
+                        self.emit_op(Opcode::LdReg(tmp.into(), lhs_reg));
+                        let loop_addr = self.current_addr();
+                        // tmp -= rhs, VF=1 なら borrow なし (tmp >= rhs)
+                        self.emit_op(Opcode::Sub(tmp.into(), rhs_reg));
+                        // VF == 0 (borrow) なら終了
+                        self.emit_op(Opcode::SneImm(Register::VF, 0));
+                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+                        let jp_break = self.emit_placeholder();
+                        let one = self.alloc_temp_register();
+                        self.emit_op(Opcode::LdImm(one.into(), 1));
+                        self.emit_op(Opcode::Add(quotient.into(), one.into()));
+                        self.emit_op(Opcode::Jp(loop_addr));
+                        let break_addr = self.current_addr();
+                        self.patch_at(jp_break, Opcode::Jp(break_addr));
+                        return ValueLocation::InRegister(quotient.into());
+                    }
+                    BinOp::Mod => {
+                        // ソフトウェア剰余: lhs から rhs を引き続け、残りを返す
+                        let tmp = self.alloc_temp_register();
+                        self.emit_op(Opcode::LdReg(tmp.into(), lhs_reg));
+                        let loop_addr = self.current_addr();
+                        self.emit_op(Opcode::Sub(tmp.into(), rhs_reg));
+                        // VF == 0 (borrow) なら tmp < rhs だった → 戻して終了
+                        self.emit_op(Opcode::SneImm(Register::VF, 0));
+                        self.emit_op(Opcode::Jp(self.skip_next_addr()));
+                        let jp_break = self.emit_placeholder();
+                        self.emit_op(Opcode::Jp(loop_addr));
+                        let break_addr = self.current_addr();
+                        self.patch_at(jp_break, Opcode::Jp(break_addr));
+                        // SUB で壊れた tmp に rhs を足し戻す
+                        self.emit_op(Opcode::Add(tmp.into(), rhs_reg));
+                        return ValueLocation::InRegister(tmp.into());
+                    }
                     // Eq/NotEq は上で早期リターン済み
                     BinOp::Eq | BinOp::NotEq => unreachable!(),
                     BinOp::Lt => {
@@ -913,6 +1031,19 @@ impl CodeGen {
                 let then_loc = self.codegen_expr(then_block);
 
                 if let Some(else_block) = else_block {
+                    // then ブランチの InMemory → V0..V(n-1) にロード
+                    let then_is_memory = matches!(&then_loc, ValueLocation::InMemory { .. });
+                    if let ValueLocation::InMemory {
+                        addr,
+                        ref struct_name,
+                    } = then_loc
+                    {
+                        let count = self.struct_field_count(struct_name);
+                        self.emit_op(Opcode::LdI(Addr::new(addr)));
+                        let last = UserRegister::new(count as u8 - 1);
+                        self.emit_op(Opcode::LdVxI(last.into()));
+                    }
+
                     let jp_end_offset = self.emit_placeholder();
 
                     let else_addr = self.current_addr();
@@ -920,12 +1051,26 @@ impl CodeGen {
 
                     let else_loc = self.codegen_expr(else_block);
 
-                    if let (Some(_tr), Some(_er)) = (then_loc.register(), else_loc.register()) {}
+                    // else ブランチの InMemory → V0..V(n-1) にロード
+                    let else_is_memory = matches!(&else_loc, ValueLocation::InMemory { .. });
+                    if let ValueLocation::InMemory {
+                        addr,
+                        ref struct_name,
+                    } = else_loc
+                    {
+                        let count = self.struct_field_count(struct_name);
+                        self.emit_op(Opcode::LdI(Addr::new(addr)));
+                        let last = UserRegister::new(count as u8 - 1);
+                        self.emit_op(Opcode::LdVxI(last.into()));
+                    }
 
                     let end_addr = self.current_addr();
                     self.patch_at(jp_end_offset, Opcode::Jp(end_addr));
 
                     match (then_loc, else_loc) {
+                        _ if then_is_memory || else_is_memory => {
+                            ValueLocation::InRegister(Register::V0)
+                        }
                         (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         (ValueLocation::InRegister(r), _) => ValueLocation::InRegister(r),
                         _ => ValueLocation::Void,
@@ -1393,6 +1538,43 @@ impl CodeGen {
                     if val_reg != target {
                         self.emit_op(Opcode::LdReg(target, val_reg));
                     }
+                } else if let Some(val_reg) = val_loc.register()
+                    && self.mutable_globals.contains(name)
+                {
+                    // ミュータブルグローバル変数への書き込み
+                    self.emit_global_write(name, val_reg);
+                }
+            }
+            StmtKind::IndexAssign {
+                array,
+                index,
+                value,
+            } => {
+                let Some(idx_reg) = self.codegen_expr(index).register() else {
+                    return;
+                };
+                let Some(val_reg) = self.codegen_expr(value).register() else {
+                    return;
+                };
+                // V0 に値をセット → I = base + index → FX55 で書き込み
+                if val_reg == Register::V0 {
+                    self.emit_ld_i_global(array);
+                    self.emit_op(Opcode::AddI(idx_reg));
+                    self.emit_op(Opcode::LdIVx(Register::V0));
+                } else if self.v0_is_bound() {
+                    // V0 退避 → 値を V0 に → 書き込み → V0 復帰
+                    let tmp = self.alloc_temp_register();
+                    self.emit_op(Opcode::LdReg(tmp.into(), Register::V0));
+                    self.emit_op(Opcode::LdReg(Register::V0, val_reg));
+                    self.emit_ld_i_global(array);
+                    self.emit_op(Opcode::AddI(idx_reg));
+                    self.emit_op(Opcode::LdIVx(Register::V0));
+                    self.emit_op(Opcode::LdReg(Register::V0, tmp.into()));
+                } else {
+                    self.emit_op(Opcode::LdReg(Register::V0, val_reg));
+                    self.emit_ld_i_global(array);
+                    self.emit_op(Opcode::AddI(idx_reg));
+                    self.emit_op(Opcode::LdIVx(Register::V0));
                 }
             }
             StmtKind::Expr(expr) => {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -276,6 +276,7 @@ impl Lexer {
             "match" => TokenKind::Match,
             "enum" => TokenKind::Enum,
             "struct" => TokenKind::Struct,
+            "mut" => TokenKind::Mut,
             _ => TokenKind::Ident(s),
         };
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -21,6 +21,7 @@ pub enum TokenKind {
     Match,
     Enum,
     Struct,
+    Mut,
 
     // リテラル
     IntLiteral(u64),

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -118,8 +118,20 @@ pub struct Stmt {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StmtKind {
-    Let { name: String, ty: Type, value: Expr },
-    Assign { name: String, value: Expr },
+    Let {
+        name: String,
+        ty: Type,
+        value: Expr,
+    },
+    Assign {
+        name: String,
+        value: Expr,
+    },
+    IndexAssign {
+        array: String,
+        index: Expr,
+        value: Expr,
+    },
     Expr(Expr),
     Return(Option<Expr>),
     Break,
@@ -153,6 +165,7 @@ pub enum TopLevel {
         name: String,
         ty: Type,
         value: Expr,
+        mutable: bool,
         span: Span,
     },
     EnumDef {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -185,6 +185,10 @@ impl Parser {
     fn parse_let_def(&mut self) -> Result<TopLevel, ParseError> {
         let span = self.current_span();
         self.expect(&TokenKind::Let)?;
+        let mutable = *self.peek() == TokenKind::Mut;
+        if mutable {
+            self.advance();
+        }
         let (name, _) = self.expect_ident()?;
         self.expect(&TokenKind::Colon)?;
         let ty = self.parse_type()?;
@@ -195,6 +199,7 @@ impl Parser {
             name,
             ty,
             value,
+            mutable,
             span,
         })
     }
@@ -346,17 +351,41 @@ impl Parser {
             }
             _ => {
                 let expr = self.parse_expr()?;
-                // 代入: ident = expr;
-                if self.peek() == &TokenKind::Eq
-                    && let ExprKind::Ident(name) = expr.kind
-                {
-                    self.advance(); // '='
-                    let value = self.parse_expr()?;
-                    self.expect(&TokenKind::Semicolon)?;
-                    return Ok(Stmt {
-                        kind: StmtKind::Assign { name, value },
-                        span,
-                    });
+                if self.peek() == &TokenKind::Eq {
+                    if matches!(&expr.kind, ExprKind::Ident(_)) {
+                        let ExprKind::Ident(name) = expr.kind else {
+                            unreachable!()
+                        };
+                        self.advance(); // '='
+                        let value = self.parse_expr()?;
+                        self.expect(&TokenKind::Semicolon)?;
+                        return Ok(Stmt {
+                            kind: StmtKind::Assign { name, value },
+                            span,
+                        });
+                    }
+                    if matches!(
+                        &expr.kind,
+                        ExprKind::Index { array, .. } if matches!(&array.kind, ExprKind::Ident(_))
+                    ) {
+                        let ExprKind::Index { array, index } = expr.kind else {
+                            unreachable!()
+                        };
+                        let ExprKind::Ident(array_name) = array.kind else {
+                            unreachable!()
+                        };
+                        self.advance(); // '='
+                        let value = self.parse_expr()?;
+                        self.expect(&TokenKind::Semicolon)?;
+                        return Ok(Stmt {
+                            kind: StmtKind::IndexAssign {
+                                array: array_name,
+                                index: *index,
+                                value,
+                            },
+                            span,
+                        });
+                    }
                 }
                 self.expect(&TokenKind::Semicolon)?;
                 Ok(Stmt {
@@ -678,12 +707,36 @@ impl Parser {
                 });
             } else if self.peek() == &TokenKind::Eq {
                 // 代入文
-                if let ExprKind::Ident(name) = expr.kind {
+                if matches!(&expr.kind, ExprKind::Ident(_)) {
+                    let ExprKind::Ident(name) = expr.kind else {
+                        unreachable!()
+                    };
                     self.advance();
                     let value = self.parse_expr()?;
                     self.expect(&TokenKind::Semicolon)?;
                     stmts.push(Stmt {
                         kind: StmtKind::Assign { name, value },
+                        span: self.tokens[checkpoint].span,
+                    });
+                } else if matches!(
+                    &expr.kind,
+                    ExprKind::Index { array, .. } if matches!(&array.kind, ExprKind::Ident(_))
+                ) {
+                    let ExprKind::Index { array, index } = expr.kind else {
+                        unreachable!()
+                    };
+                    let ExprKind::Ident(array_name) = array.kind else {
+                        unreachable!()
+                    };
+                    self.advance();
+                    let value = self.parse_expr()?;
+                    self.expect(&TokenKind::Semicolon)?;
+                    stmts.push(Stmt {
+                        kind: StmtKind::IndexAssign {
+                            array: array_name,
+                            index: *index,
+                            value,
+                        },
                         span: self.tokens[checkpoint].span,
                     });
                 } else {

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -640,3 +640,45 @@ fn test_many_struct_params_no_overflow() {
          fn main() -> () { }",
     );
 }
+
+#[test]
+fn test_mutable_global_ok() {
+    analyze_ok(
+        "let mut score: u8 = 0;
+         fn main() -> () {
+            score = 10;
+         }",
+    );
+}
+
+#[test]
+fn test_immutable_global_assign_error() {
+    analyze_err_matches(
+        "let score: u8 = 0;
+         fn main() -> () {
+            score = 10;
+         }",
+        |k| matches!(k, AnalyzeErrorKind::ImmutableAssignment(_)),
+    );
+}
+
+#[test]
+fn test_array_index_assign_ok() {
+    analyze_ok(
+        "let mut board: [u8; 4] = [0, 0, 0, 0];
+         fn main() -> () {
+            board[2] = 42;
+         }",
+    );
+}
+
+#[test]
+fn test_immutable_array_assign_error() {
+    analyze_err_matches(
+        "let board: [u8; 4] = [0, 0, 0, 0];
+         fn main() -> () {
+            board[2] = 42;
+         }",
+        |k| matches!(k, AnalyzeErrorKind::ImmutableAssignment(_)),
+    );
+}

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -568,3 +568,89 @@ fn test_struct_update_memory() {
     );
     assert!(bytes.len() >= 4);
 }
+
+#[test]
+fn test_if_else_returns_struct_from_memory() {
+    // #40: if-else で struct (InMemory) を返す場合のバグ修正
+    let bytes = compile(
+        "struct Pos { x: u8, y: u8 }
+         fn choose(c: bool, a: Pos, b: Pos) -> Pos {
+            if c { a } else { b }
+         }
+         fn main() -> u8 {
+            let p: Pos = choose(true, Pos { x: 1, y: 2 }, Pos { x: 3, y: 4 });
+            p.x
+         }",
+    );
+    assert!(bytes.len() >= 4);
+}
+
+#[test]
+fn test_mul_compiles() {
+    let bytes = compile(
+        "fn main() -> u8 {
+            let a: u8 = 3;
+            let b: u8 = 4;
+            a * b
+         }",
+    );
+    assert!(bytes.len() >= 4);
+    // JP 命令が含まれること (ループ)
+    let jp_count = bytes.chunks(2).filter(|c| (c[0] & 0xF0) == 0x10).count();
+    assert!(jp_count >= 2, "expected JP instructions for mul loop");
+}
+
+#[test]
+fn test_div_compiles() {
+    let bytes = compile(
+        "fn main() -> u8 {
+            let a: u8 = 12;
+            let b: u8 = 3;
+            a / b
+         }",
+    );
+    assert!(bytes.len() >= 4);
+}
+
+#[test]
+fn test_mod_compiles() {
+    let bytes = compile(
+        "fn main() -> u8 {
+            let a: u8 = 10;
+            let b: u8 = 3;
+            a % b
+         }",
+    );
+    assert!(bytes.len() >= 4);
+}
+
+#[test]
+fn test_mutable_global_read_write() {
+    let bytes = compile(
+        "let mut score: u8 = 0;
+         fn add_score(points: u8) -> () {
+            score = score + points;
+         }
+         fn main() -> () {
+            add_score(10);
+         }",
+    );
+    assert!(bytes.len() >= 4);
+    // FX55 (LdIVx) が含まれること (グローバル書き込み)
+    let has_fx55 = bytes.chunks(2).any(|c| (c[1] & 0xFF) == 0x55);
+    assert!(has_fx55, "expected FX55 instruction for global write");
+}
+
+#[test]
+fn test_array_index_assign_compiles() {
+    let bytes = compile(
+        "let mut board: [u8; 4] = [0, 0, 0, 0];
+         fn main() -> () {
+            board[2] = 42;
+         }",
+    );
+    assert!(bytes.len() >= 4);
+    // FX1E (AddI) が含まれること (インデックス計算)
+    let has_fx1e = bytes.chunks(2).any(|c| (c[1] & 0xFF) == 0x1E);
+    assert!(has_fx1e, "expected FX1E instruction for index calculation");
+}


### PR DESCRIPTION
## Summary

- **#6** (caller-save): 実装済みのためクローズ
- **#40** (struct if-else バグ): if-else で InMemory を返す場合に Void になるバグを修正
- **#8** (Mul/Div/Mod): ソフトウェアループによる乗算・除算・剰余演算を実装
- **#9** (mutable globals): `let mut` 構文によるミュータブルグローバル変数をサポート
- **#10** (配列書き込み): `array[i] = val` 構文による配列インデックス代入をサポート

## Changes

### #40 fix: if-else InMemory handling
- `codegen_expr` / `codegen_expr_tail` の if-else で InMemory 結果を V0..V(n-1) にロードしてから返すように変更

### #8: Mul/Div/Mod
- CHIP-8 に乗除命令がないため、加算/減算ループで実装

### #9: Mutable globals
- Lexer: `Mut` トークン追加
- Parser: `let mut` パース
- AST: `LetDef.mutable` フィールド
- Analyzer: `ImmutableAssignment` エラー
- CodeGen: `emit_global_write` (LdI + FX55)

### #10: Array index assign
- AST: `StmtKind::IndexAssign`
- Parser: `ident[expr] = expr` (stmt + block 両対応)
- CodeGen: LdI + AddI + FX55

## Test plan
- [x] `cargo test` — 全 165 テスト通過 (新規 10 テスト)
- [x] `cargo clippy` — 警告なし
- [x] `cargo fmt --check` — OK

Closes #40, Closes #8, Closes #9, Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)