### PR TITLE
fix: #42 ネスト struct のフィールドアクセス修正

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -940,9 +940,11 @@ impl CodeGen {
                         }
                     }
                 }
-                let num_to_save = self.local_var_count;
+                // caller-save: 全ライブレジスタをメモリに退避
+                // local_var_count ではなく next_free_reg を使い、
+                // 一時レジスタ (前の関数呼び出しの戻り値等) も保護する
+                let num_to_save = self.next_free_reg;
 
-                // caller-save: ローカル変数をメモリに退避
                 let save_addr = self.next_save_slot;
                 if num_to_save > 0 {
                     self.emit_op(Opcode::LdI(Addr::new(save_addr)));
@@ -1002,19 +1004,21 @@ impl CodeGen {
                         struct_name: ret_struct_name,
                     }
                 } else {
-                    // スカラー戻り値: 従来通り
-                    let result_reg = if num_to_save > 0 {
-                        let temp = UserRegister::new(num_to_save);
-                        self.emit_op(Opcode::LdReg(temp.into(), Register::V0));
+                    // スカラー戻り値: 新しい一時レジスタに退避して
+                    // 後続の式評価で V0 が上書きされても安全にする
+                    let result_temp = self.alloc_temp_register();
+                    if Register::from(result_temp) != Register::V0 {
+                        self.emit_op(Opcode::LdReg(result_temp.into(), Register::V0));
+                    }
+
+                    // caller-save 復帰
+                    if num_to_save > 0 {
                         self.emit_op(Opcode::LdI(Addr::new(save_addr)));
                         let last_reg = UserRegister::new(num_to_save - 1);
                         self.emit_op(Opcode::LdVxI(last_reg.into()));
-                        temp.into()
-                    } else {
-                        Register::V0
-                    };
+                    }
 
-                    ValueLocation::InRegister(result_reg)
+                    ValueLocation::InRegister(result_temp.into())
                 }
             }
             ExprKind::If {

--- a/tests/chip8_interpreter.rs
+++ b/tests/chip8_interpreter.rs
@@ -1,0 +1,223 @@
+/// CHIP-8 ミニインタプリタ (テスト用)
+///
+/// コンパイラが生成するオペコードのみサポート。
+/// 描画・タイマー・キー入力命令は NOP 扱い。
+
+const MEM_SIZE: usize = 4096;
+const PROGRAM_START: u16 = 0x200;
+const MAX_CYCLES: usize = 10000;
+
+pub struct Chip8 {
+    mem: [u8; MEM_SIZE],
+    v: [u8; 16],
+    i: u16,
+    pc: u16,
+    stack: Vec<u16>,
+}
+
+impl Chip8 {
+    pub fn new(program: &[u8]) -> Self {
+        let mut mem = [0u8; MEM_SIZE];
+        let start = PROGRAM_START as usize;
+        let end = start + program.len();
+        mem[start..end].copy_from_slice(program);
+        Chip8 {
+            mem,
+            v: [0; 16],
+            i: 0,
+            pc: PROGRAM_START,
+            stack: Vec::new(),
+        }
+    }
+
+    /// プログラムを実行し、停止時の V0 を返す。
+    /// ハング検出時は None。
+    pub fn run_and_get_v0(&mut self) -> Option<u8> {
+        for _ in 0..MAX_CYCLES {
+            let hi = self.mem[self.pc as usize] as u16;
+            let lo = self.mem[self.pc as usize + 1] as u16;
+            let op = (hi << 8) | lo;
+
+            let nnn = op & 0x0FFF;
+            let x = ((op >> 8) & 0x0F) as usize;
+            let y = ((op >> 4) & 0x0F) as usize;
+            let kk = (op & 0xFF) as u8;
+            let nibble = (op & 0x0F) as u8;
+
+            match op & 0xF000 {
+                0x0000 => match op {
+                    0x00E0 => {
+                        // CLS - nop
+                        self.pc += 2;
+                    }
+                    0x00EE => {
+                        // RET
+                        if let Some(addr) = self.stack.pop() {
+                            self.pc = addr;
+                        } else {
+                            // スタック空 = main 終了
+                            return Some(self.v[0]);
+                        }
+                    }
+                    _ => self.pc += 2, // unknown 0xxx - skip
+                },
+                0x1000 => {
+                    // JP nnn
+                    if nnn == self.pc {
+                        // jump-to-self = halt
+                        return Some(self.v[0]);
+                    }
+                    self.pc = nnn;
+                }
+                0x2000 => {
+                    // CALL nnn
+                    self.stack.push(self.pc + 2);
+                    self.pc = nnn;
+                }
+                0x3000 => {
+                    // SE Vx, kk
+                    self.pc += if self.v[x] == kk { 4 } else { 2 };
+                }
+                0x4000 => {
+                    // SNE Vx, kk
+                    self.pc += if self.v[x] != kk { 4 } else { 2 };
+                }
+                0x5000 => {
+                    // SE Vx, Vy
+                    self.pc += if self.v[x] == self.v[y] { 4 } else { 2 };
+                }
+                0x6000 => {
+                    // LD Vx, kk
+                    self.v[x] = kk;
+                    self.pc += 2;
+                }
+                0x7000 => {
+                    // ADD Vx, kk
+                    self.v[x] = self.v[x].wrapping_add(kk);
+                    self.pc += 2;
+                }
+                0x8000 => {
+                    match nibble {
+                        0x0 => self.v[x] = self.v[y],
+                        0x1 => self.v[x] |= self.v[y],
+                        0x2 => self.v[x] &= self.v[y],
+                        0x3 => self.v[x] ^= self.v[y],
+                        0x4 => {
+                            let sum = self.v[x] as u16 + self.v[y] as u16;
+                            self.v[0xF] = if sum > 255 { 1 } else { 0 };
+                            self.v[x] = sum as u8;
+                        }
+                        0x5 => {
+                            self.v[0xF] = if self.v[x] >= self.v[y] { 1 } else { 0 };
+                            self.v[x] = self.v[x].wrapping_sub(self.v[y]);
+                        }
+                        0x6 => {
+                            self.v[0xF] = self.v[y] & 1;
+                            self.v[x] = self.v[y] >> 1;
+                        }
+                        0x7 => {
+                            self.v[0xF] = if self.v[y] >= self.v[x] { 1 } else { 0 };
+                            self.v[x] = self.v[y].wrapping_sub(self.v[x]);
+                        }
+                        0xE => {
+                            self.v[0xF] = (self.v[y] >> 7) & 1;
+                            self.v[x] = self.v[y] << 1;
+                        }
+                        _ => {}
+                    }
+                    self.pc += 2;
+                }
+                0x9000 => {
+                    // SNE Vx, Vy
+                    self.pc += if self.v[x] != self.v[y] { 4 } else { 2 };
+                }
+                0xA000 => {
+                    // LD I, nnn
+                    self.i = nnn;
+                    self.pc += 2;
+                }
+                0xB000 => {
+                    // JP V0, nnn
+                    self.pc = nnn + self.v[0] as u16;
+                }
+                0xC000 => {
+                    // RND Vx, kk - テスト用に固定値
+                    self.v[x] = 0x42 & kk;
+                    self.pc += 2;
+                }
+                0xD000 => {
+                    // DRW - nop (collision = 0)
+                    self.v[0xF] = 0;
+                    self.pc += 2;
+                }
+                0xE000 => {
+                    match kk {
+                        0x9E => {
+                            // SKP - キー未押下として扱う
+                            self.pc += 2;
+                        }
+                        0xA1 => {
+                            // SKNP - キー未押下として扱う → スキップ
+                            self.pc += 4;
+                        }
+                        _ => self.pc += 2,
+                    }
+                }
+                0xF000 => {
+                    match kk {
+                        0x07 => {
+                            // LD Vx, DT - タイマー = 0
+                            self.v[x] = 0;
+                            self.pc += 2;
+                        }
+                        0x0A => {
+                            // LD Vx, K - テスト用に 0 を返す
+                            self.v[x] = 0;
+                            self.pc += 2;
+                        }
+                        0x15 | 0x18 => {
+                            // LD DT/ST - nop
+                            self.pc += 2;
+                        }
+                        0x1E => {
+                            // ADD I, Vx
+                            self.i += self.v[x] as u16;
+                            self.pc += 2;
+                        }
+                        0x29 => {
+                            // LD F, Vx - フォントアドレス
+                            self.i = (self.v[x] as u16) * 5;
+                            self.pc += 2;
+                        }
+                        0x33 => {
+                            // BCD
+                            let val = self.v[x];
+                            self.mem[self.i as usize] = val / 100;
+                            self.mem[self.i as usize + 1] = (val / 10) % 10;
+                            self.mem[self.i as usize + 2] = val % 10;
+                            self.pc += 2;
+                        }
+                        0x55 => {
+                            // LD [I], V0..Vx
+                            for r in 0..=x {
+                                self.mem[self.i as usize + r] = self.v[r];
+                            }
+                            self.pc += 2;
+                        }
+                        0x65 => {
+                            // LD V0..Vx, [I]
+                            for r in 0..=x {
+                                self.v[r] = self.mem[self.i as usize + r];
+                            }
+                            self.pc += 2;
+                        }
+                        _ => self.pc += 2,
+                    }
+                }
+                _ => self.pc += 2,
+            }
+        }
+        // サイクル上限到達 = ハング
+        None
+    }
+}

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -2,6 +2,8 @@ use chip8_lang::codegen::CodeGen;
 use chip8_lang::lexer::Lexer;
 use chip8_lang::parser::Parser;
 
+mod chip8_interpreter;
+
 fn compile(input: &str) -> Vec<u8> {
     let mut lexer = Lexer::new(input);
     let tokens = lexer.tokenize().unwrap();
@@ -9,6 +11,12 @@ fn compile(input: &str) -> Vec<u8> {
     let program = parser.parse_program().unwrap();
     let mut codegen = CodeGen::new();
     codegen.generate(&program)
+}
+
+fn compile_and_run(input: &str) -> u8 {
+    let bytes = compile(input);
+    let mut vm = chip8_interpreter::Chip8::new(&bytes);
+    vm.run_and_get_v0().expect("program hanged (cycle limit)")
 }
 
 #[test]
@@ -653,4 +661,257 @@ fn test_array_index_assign_compiles() {
     // FX1E (AddI) が含まれること (インデックス計算)
     let has_fx1e = bytes.chunks(2).any(|c| (c[1] & 0xFF) == 0x1E);
     assert!(has_fx1e, "expected FX1E instruction for index calculation");
+}
+
+// ============================================================
+// CHIP-8 インタプリタによる実行検証テスト
+// ============================================================
+
+#[test]
+fn test_run_simple_return() {
+    assert_eq!(compile_and_run("fn main() -> u8 { 42 }"), 42);
+}
+
+#[test]
+fn test_run_flat_struct_field_access() {
+    assert_eq!(
+        compile_and_run(
+            "struct Big { a: u8, b: u8, c: u8, d: u8, e: u8 }
+             fn get_e(s: Big) -> u8 { s.e }
+             fn main() -> u8 {
+                get_e(Big { a: 1, b: 3, c: 5, d: 7, e: 9 })
+             }"
+        ),
+        9
+    );
+}
+
+#[test]
+fn test_run_flat_struct_first_field() {
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             fn get_x(p: Pos) -> u8 { p.x }
+             fn main() -> u8 {
+                get_x(Pos { x: 42, y: 10 })
+             }"
+        ),
+        42
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_speed() {
+    // Issue #42: ネスト struct のスカラーフィールド (nested struct の後ろ)
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_speed(s: GameState) -> u8 { s.speed }
+             fn main() -> u8 {
+                get_speed(GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 })
+             }"
+        ),
+        9
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_pos_x() {
+    // Issue #42: ネスト struct のフィールドアクセス
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_px(s: GameState) -> u8 { s.pos.x }
+             fn main() -> u8 {
+                get_px(GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 })
+             }"
+        ),
+        2
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_pos_y() {
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_py(s: GameState) -> u8 { s.pos.y }
+             fn main() -> u8 {
+                get_py(GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 })
+             }"
+        ),
+        3
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_score() {
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_score(s: GameState) -> u8 { s.score }
+             fn main() -> u8 {
+                get_score(GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 })
+             }"
+        ),
+        8
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_piece() {
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_piece(s: GameState) -> u8 { s.piece }
+             fn main() -> u8 {
+                get_piece(GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 })
+             }"
+        ),
+        1
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_with_let() {
+    // let バインド経由でネスト struct を渡す
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_speed(s: GameState) -> u8 { s.speed }
+             fn main() -> u8 {
+                let gs: GameState = GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 };
+                get_speed(gs)
+             }"
+        ),
+        9
+    );
+}
+
+#[test]
+fn test_run_issue42_nested_struct_let_and_local() {
+    // let バインド + 他のローカル変数がある場合
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_speed(s: GameState) -> u8 { s.speed }
+             fn main() -> u8 {
+                let x: u8 = 100;
+                let gs: GameState = GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 };
+                get_speed(gs)
+             }"
+        ),
+        9
+    );
+}
+
+#[test]
+fn test_run_issue42_multiple_nested_calls() {
+    // 複数のフィールドアクセスを別々の関数で
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn get_speed(s: GameState) -> u8 { s.speed }
+             fn get_score(s: GameState) -> u8 { s.score }
+             fn main() -> u8 {
+                let gs: GameState = GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 8, speed: 9 };
+                let sp: u8 = get_speed(gs);
+                let sc: u8 = get_score(gs);
+                sp + sc
+             }"
+        ),
+        17
+    );
+}
+
+#[test]
+fn test_run_issue42_deeply_nested() {
+    // 3 段ネスト
+    assert_eq!(
+        compile_and_run(
+            "struct Inner { val: u8 }
+             struct Mid { inner: Inner, tag: u8 }
+             struct Outer { mid: Mid, extra: u8 }
+             fn get_val(o: Outer) -> u8 { o.mid.inner.val }
+             fn get_extra(o: Outer) -> u8 { o.extra }
+             fn main() -> u8 {
+                let o: Outer = Outer { mid: Mid { inner: Inner { val: 77 }, tag: 88 }, extra: 99 };
+                get_val(o) + get_extra(o)
+             }"
+        ),
+        176 // 77 + 99
+    );
+}
+
+#[test]
+fn test_run_issue42_deeply_nested_val_only() {
+    // 3 段ネストで inner.val だけ取得
+    assert_eq!(
+        compile_and_run(
+            "struct Inner { val: u8 }
+             struct Mid { inner: Inner, tag: u8 }
+             struct Outer { mid: Mid, extra: u8 }
+             fn get_val(o: Outer) -> u8 { o.mid.inner.val }
+             fn main() -> u8 {
+                get_val(Outer { mid: Mid { inner: Inner { val: 77 }, tag: 88 }, extra: 99 })
+             }"
+        ),
+        77
+    );
+}
+
+#[test]
+fn test_run_issue42_deeply_nested_tag() {
+    assert_eq!(
+        compile_and_run(
+            "struct Inner { val: u8 }
+             struct Mid { inner: Inner, tag: u8 }
+             struct Outer { mid: Mid, extra: u8 }
+             fn get_tag(o: Outer) -> u8 { o.mid.tag }
+             fn main() -> u8 {
+                get_tag(Outer { mid: Mid { inner: Inner { val: 77 }, tag: 88 }, extra: 99 })
+             }"
+        ),
+        88
+    );
+}
+
+#[test]
+fn test_run_issue42_deeply_nested_extra() {
+    assert_eq!(
+        compile_and_run(
+            "struct Inner { val: u8 }
+             struct Mid { inner: Inner, tag: u8 }
+             struct Outer { mid: Mid, extra: u8 }
+             fn get_extra(o: Outer) -> u8 { o.extra }
+             fn main() -> u8 {
+                get_extra(Outer { mid: Mid { inner: Inner { val: 77 }, tag: 88 }, extra: 99 })
+             }"
+        ),
+        99
+    );
+}
+
+#[test]
+fn test_run_issue42_mid_struct_access() {
+    // 2 段ネスト: Mid { inner: Inner, tag } 直接
+    assert_eq!(
+        compile_and_run(
+            "struct Inner { val: u8 }
+             struct Mid { inner: Inner, tag: u8 }
+             fn get_tag(m: Mid) -> u8 { m.tag }
+             fn main() -> u8 {
+                get_tag(Mid { inner: Inner { val: 77 }, tag: 88 })
+             }"
+        ),
+        88
+    );
 }


### PR DESCRIPTION
## Summary
- caller-save の保存範囲を `local_var_count` → `next_free_reg` に変更し、一時レジスタ（前の関数呼び出しの戻り値等）も保護
- スカラー戻り値を常に新しい一時レジスタに退避し、後続の式評価で V0 が上書きされても安全に
- テスト用 CHIP-8 ミニインタプリタ (`tests/chip8_interpreter.rs`) を追加し、実行レベルで正しさを検証
- ネスト struct (2段・3段) のフィールドアクセス、複数関数呼び出しの組み合わせ等 16 テスト追加

Closes #42

## Test plan
- [x] `cargo test` — 全 181 テスト通過 (新規 16 テスト含む)
- [x] `cargo clippy` — lint 通過
- [x] `cargo fmt --check` — フォーマット通過
- [x] ネスト struct の全フィールド (piece, pos.x, pos.y, score, speed) が正しい値を返すことをインタプリタで検証
- [x] 3段ネスト struct + 複数関数呼び出しの組み合わせが正しく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)