### PR TITLE
fix: #46 struct 一括コピーがローカルレジスタを破壊するバグを修正

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -538,6 +538,17 @@ impl CodeGen {
         }
     }
 
+    /// メモリ間コピー (レジスタを破壊しない)
+    /// emit_load_from_memory / emit_store_to_memory の XOR swap により
+    /// V0 を含む全ライブレジスタを保護する
+    fn emit_memcpy(&mut self, src_addr: u16, dst_addr: u16, count: usize) {
+        let tmp = self.alloc_temp_register();
+        for i in 0..count {
+            self.emit_load_from_memory(tmp.into(), src_addr + i as u16);
+            self.emit_store_to_memory(tmp.into(), dst_addr + i as u16);
+        }
+    }
+
     fn pattern_value(&self, pattern: &Expr) -> u8 {
         match &pattern.kind {
             ExprKind::IntLiteral(v) => *v as u8,
@@ -1163,12 +1174,7 @@ impl CodeGen {
                 if let Some(base_expr) = base {
                     let base_loc = self.codegen_expr(base_expr);
                     if let ValueLocation::InMemory { addr: src_addr, .. } = base_loc {
-                        // メモリ → メモリ: V0..V(n-1) 経由でコピー
-                        self.emit_op(Opcode::LdI(Addr::new(src_addr)));
-                        let last = UserRegister::new(field_count as u8 - 1);
-                        self.emit_op(Opcode::LdVxI(last.into()));
-                        self.emit_op(Opcode::LdI(Addr::new(struct_addr)));
-                        self.emit_op(Opcode::LdIVx(last.into()));
+                        self.emit_memcpy(src_addr, struct_addr, field_count);
                     }
                 }
 
@@ -1187,11 +1193,7 @@ impl CodeGen {
                             let val_loc = self.codegen_expr(value_expr);
                             let sub_count = self.struct_field_count(sub_name);
                             if let ValueLocation::InMemory { addr: src_addr, .. } = val_loc {
-                                self.emit_op(Opcode::LdI(Addr::new(src_addr)));
-                                let last = UserRegister::new(sub_count as u8 - 1);
-                                self.emit_op(Opcode::LdVxI(last.into()));
-                                self.emit_op(Opcode::LdI(Addr::new(struct_addr + offset as u16)));
-                                self.emit_op(Opcode::LdIVx(last.into()));
+                                self.emit_memcpy(src_addr, struct_addr + offset as u16, sub_count);
                             }
                             continue;
                         }
@@ -1520,11 +1522,7 @@ impl CodeGen {
                             ref struct_name,
                         } => {
                             let count = self.struct_field_count(struct_name);
-                            self.emit_op(Opcode::LdI(Addr::new(src_addr)));
-                            let last = UserRegister::new(count as u8 - 1);
-                            self.emit_op(Opcode::LdVxI(last.into()));
-                            self.emit_op(Opcode::LdI(Addr::new(target_addr)));
-                            self.emit_op(Opcode::LdIVx(last.into()));
+                            self.emit_memcpy(src_addr, target_addr, count);
                         }
                         _ => {
                             if let Some(val_reg) = val_loc.register() {

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -988,3 +988,90 @@ fn test_run_issue44_struct_all_fields_after_pass() {
         60
     );
 }
+
+// ===== Issue #46: ネスト struct コピーがレジスタを破壊するバグ =====
+
+#[test]
+fn test_run_issue46_nested_struct_literal_preserves_registers() {
+    // ネスト struct (Pos) のコピーで V0/V1 が破壊されないこと
+    // バグだと score = 0 になる (V1 が Pos.y = 0 で上書きされる)
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn make_gs(p: u8, sc: u8, sp: u8) -> GameState {
+                GameState { piece: p, pos: Pos { x: 28, y: 0 }, score: sc, speed: sp }
+             }
+             fn main() -> u8 {
+                let gs: GameState = make_gs(1, 6, 15);
+                gs.score
+             }"
+        ),
+        6
+    );
+}
+
+#[test]
+fn test_run_issue46_on_land_pattern() {
+    // issue #46 の再現パターン: update_score 後に struct フィールドが壊れない
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn use_val(v: u8) -> u8 { v }
+             fn make_gs(p: u8, sc: u8, sp: u8) -> GameState {
+                GameState { piece: p, pos: Pos { x: 28, y: 0 }, score: sc, speed: sp }
+             }
+             fn on_land(state: GameState) -> GameState {
+                use_val(state.score);
+                let p: u8 = 7;
+                make_gs(p, state.score + 1, state.speed)
+             }
+             fn main() -> u8 {
+                let s: GameState = GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 5, speed: 15 };
+                let r: GameState = on_land(s);
+                r.score
+             }"
+        ),
+        6
+    );
+}
+
+#[test]
+fn test_run_issue46_struct_update_syntax_preserves_registers() {
+    // struct update syntax (base) でレジスタが壊れないこと
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn update(gs: GameState) -> GameState {
+                GameState { ..gs, score: gs.score + 1 }
+             }
+             fn main() -> u8 {
+                let s: GameState = GameState { piece: 1, pos: Pos { x: 2, y: 3 }, score: 10, speed: 20 };
+                let r: GameState = update(s);
+                r.score
+             }"
+        ),
+        11
+    );
+}
+
+#[test]
+fn test_run_issue46_nested_struct_piece_preserved() {
+    // ネスト struct コピー後に piece (V0) が壊れないこと
+    assert_eq!(
+        compile_and_run(
+            "struct Pos { x: u8, y: u8 }
+             struct GameState { piece: u8, pos: Pos, score: u8, speed: u8 }
+             fn make_gs(p: u8, sc: u8, sp: u8) -> GameState {
+                GameState { piece: p, pos: Pos { x: 28, y: 0 }, score: sc, speed: sp }
+             }
+             fn main() -> u8 {
+                let gs: GameState = make_gs(42, 6, 15);
+                gs.piece
+             }"
+        ),
+        42
+    );
+}


### PR DESCRIPTION
## Summary
- ネスト struct をフィールドに持つ struct リテラル生成時、`LdVxI(Vx)` で V0..Vx を一括ロードしてコピーしていたが、関数パラメータ等のローカルレジスタを破壊していた
- `emit_memcpy()` ヘルパーを追加し、フィールド単位で `emit_load_from_memory` / `emit_store_to_memory` (XOR swap) を使ってレジスタ安全にコピーするよう修正
- 3箇所の一括コピー (ネスト struct フィールド、base update syntax、struct 代入) を全て修正

## Test plan
- [x] `test_run_issue46_nested_struct_literal_preserves_registers` — 核心テスト (バグだと score=0)
- [x] `test_run_issue46_on_land_pattern` — issue #46 の再現パターン
- [x] `test_run_issue46_struct_update_syntax_preserves_registers` — base コピー
- [x] `test_run_issue46_nested_struct_piece_preserved` — V0 (piece) 保護確認
- [x] 既存テスト全 189 件通過
- [x] `cargo clippy` / `cargo fmt --check` 通過

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)