### PR TITLE
fix: #48 match式のSNE/SE論理反転を修正

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1143,7 +1143,7 @@ impl CodeGen {
                         return loc;
                     }
                     let pattern_val = self.pattern_value(&arm.pattern);
-                    self.emit_op(Opcode::SneImm(scr_reg, pattern_val));
+                    self.emit_op(Opcode::SeImm(scr_reg, pattern_val));
                     let jp_next_arm = self.emit_placeholder();
                     self.codegen_expr(&arm.body);
                     let jp_end = self.emit_placeholder();

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -213,7 +213,7 @@ fn test_design_doc_program() {
 }
 
 #[test]
-fn test_match_generates_sne_jp() {
+fn test_match_generates_se_jp() {
     let bytes = compile(
         "fn main() -> u8 {
             let x: u8 = 1;
@@ -224,12 +224,12 @@ fn test_match_generates_sne_jp() {
             }
         }",
     );
-    // match はSNE+JP パターンを生成するはず
+    // match はSE+JP パターンを生成するはず
     assert!(bytes.len() > 10);
-    // SNE (4xxx) が含まれること
+    // SE (3xxx) が含まれること
     assert!(
-        bytes.chunks(2).any(|c| c[0] & 0xF0 == 0x40),
-        "expected SNE instruction in match codegen"
+        bytes.chunks(2).any(|c| c[0] & 0xF0 == 0x30),
+        "expected SE instruction in match codegen"
     );
 }
 


### PR DESCRIPTION
## Summary

- match式のコード生成で `SneImm` を `SeImm` に変更し、正しいアームが実行されるように修正
- テスト (`test_match_generates_se_jp`) を SE (0x3xxx) に合わせて更新

Closes #48

## Test plan

- [x] `cargo test` 全テスト通過
- [x] `cargo clippy` 警告なし
- [x] `cargo fmt --check` フォーマット問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)