### PR TITLE
feat: add atomic draw batching builtins

### DIFF
--- a/src/chip8.rs
+++ b/src/chip8.rs
@@ -100,6 +100,10 @@ impl SpriteHeight {
 pub enum Opcode {
     /// 00E0 - 画面クリア
     Cls,
+    /// 00F0 - カスタム: 描画バッチ開始
+    BeginDrawBatch,
+    /// 00F1 - カスタム: 描画バッチ終了
+    EndDrawBatch,
     /// 00EE - サブルーチンからリターン
     Ret,
     /// 1NNN - アドレスにジャンプ
@@ -140,6 +144,8 @@ pub enum Opcode {
     Drw(Register, Register, SpriteHeight),
     /// EX9E - キー Vx が押されていれば次をスキップ
     Skp(Register),
+    /// EX9F - カスタム: キー Vx が直近で押されたなら次をスキップ
+    Jkp(Register),
     /// EXA1 - キー Vx が押されていなければ次をスキップ
     Sknp(Register),
     /// FX07 - Vx = ディレイタイマー
@@ -173,6 +179,8 @@ impl Opcode {
     pub fn encode(self) -> [u8; 2] {
         match self {
             Opcode::Cls => [0x00, 0xE0],
+            Opcode::BeginDrawBatch => [0x00, 0xF0],
+            Opcode::EndDrawBatch => [0x00, 0xF1],
             Opcode::Ret => [0x00, 0xEE],
             Opcode::Jp(addr) => {
                 let nnn = addr.raw();
@@ -202,6 +210,7 @@ impl Opcode {
             Opcode::Rnd(vx, kk) => [0xC0 | vx.index(), kk],
             Opcode::Drw(vx, vy, n) => [0xD0 | vx.index(), (vy.index() << 4) | n.value()],
             Opcode::Skp(vx) => [0xE0 | vx.index(), 0x9E],
+            Opcode::Jkp(vx) => [0xE0 | vx.index(), 0x9F],
             Opcode::Sknp(vx) => [0xE0 | vx.index(), 0xA1],
             Opcode::LdVxDt(vx) => [0xF0 | vx.index(), 0x07],
             Opcode::LdVxK(vx) => [0xF0 | vx.index(), 0x0A],
@@ -233,6 +242,12 @@ mod tests {
     #[test]
     fn test_cls() {
         assert_eq!(Opcode::Cls.encode(), [0x00, 0xE0]);
+    }
+
+    #[test]
+    fn test_draw_batch() {
+        assert_eq!(Opcode::BeginDrawBatch.encode(), [0x00, 0xF0]);
+        assert_eq!(Opcode::EndDrawBatch.encode(), [0x00, 0xF1]);
     }
 
     #[test]
@@ -316,6 +331,7 @@ mod tests {
     fn test_key_ops() {
         let v3 = vx(3);
         assert_eq!(Opcode::Skp(v3).encode(), [0xE3, 0x9E]);
+        assert_eq!(Opcode::Jkp(v3).encode(), [0xE3, 0x9F]);
         assert_eq!(Opcode::Sknp(v3).encode(), [0xE3, 0xA1]);
     }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1354,6 +1354,14 @@ impl CodeGen {
                 self.emit_op(Opcode::Cls);
                 ValueLocation::InRegister(Register::V0)
             }
+            BuiltinFunction::BeginDrawBatch => {
+                self.emit_op(Opcode::BeginDrawBatch);
+                ValueLocation::InRegister(Register::V0)
+            }
+            BuiltinFunction::EndDrawBatch => {
+                self.emit_op(Opcode::EndDrawBatch);
+                ValueLocation::InRegister(Register::V0)
+            }
             BuiltinFunction::Draw => {
                 if args.len() == 3
                     && let ExprKind::Ident(sprite_name) = &args[0].kind
@@ -1380,6 +1388,14 @@ impl CodeGen {
                 let res = self.alloc_temp_register();
                 self.emit_op(Opcode::LdImm(res.into(), 1));
                 self.emit_op(Opcode::Skp(key_reg));
+                self.emit_op(Opcode::LdImm(res.into(), 0));
+                ValueLocation::InRegister(res.into())
+            }
+            BuiltinFunction::IsKeyJustPressed => {
+                let key_reg = arg_regs[0];
+                let res = self.alloc_temp_register();
+                self.emit_op(Opcode::LdImm(res.into(), 1));
+                self.emit_op(Opcode::Jkp(key_reg));
                 self.emit_op(Opcode::LdImm(res.into(), 0));
                 ValueLocation::InRegister(res.into())
             }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -196,10 +196,16 @@ pub enum BuiltinFunction {
     Clear,
     /// draw(sprite, x, y) -> bool - スプライト描画 (DXYN)
     Draw,
+    /// begin_draw_batch() - 描画バッチ開始 (custom 00F0)
+    BeginDrawBatch,
+    /// end_draw_batch() - 描画バッチ終了 (custom 00F1)
+    EndDrawBatch,
     /// wait_key() -> u8 - キー入力待ち (FX0A)
     WaitKey,
     /// is_key_pressed(k: u8) -> bool - キー押下判定 (EX9E)
     IsKeyPressed,
+    /// is_key_just_pressed(k: u8) -> bool - キー押下エッジ判定 (custom EX9F)
+    IsKeyJustPressed,
     /// delay() -> u8 - ディレイタイマー読み取り (FX07)
     Delay,
     /// set_delay(v: u8) - ディレイタイマー設定 (FX15)
@@ -222,8 +228,11 @@ impl BuiltinFunction {
         match name {
             "clear" => Some(Self::Clear),
             "draw" => Some(Self::Draw),
+            "begin_draw_batch" => Some(Self::BeginDrawBatch),
+            "end_draw_batch" => Some(Self::EndDrawBatch),
             "wait_key" => Some(Self::WaitKey),
             "is_key_pressed" => Some(Self::IsKeyPressed),
+            "is_key_just_pressed" => Some(Self::IsKeyJustPressed),
             "delay" => Some(Self::Delay),
             "set_delay" => Some(Self::SetDelay),
             "set_sound" => Some(Self::SetSound),
@@ -240,8 +249,11 @@ impl BuiltinFunction {
         match self {
             Self::Clear => "clear",
             Self::Draw => "draw",
+            Self::BeginDrawBatch => "begin_draw_batch",
+            Self::EndDrawBatch => "end_draw_batch",
             Self::WaitKey => "wait_key",
             Self::IsKeyPressed => "is_key_pressed",
+            Self::IsKeyJustPressed => "is_key_just_pressed",
             Self::Delay => "delay",
             Self::SetDelay => "set_delay",
             Self::SetSound => "set_sound",
@@ -257,8 +269,11 @@ impl BuiltinFunction {
         match self {
             Self::Clear => (vec![], Type::Unit),
             Self::Draw => (vec![Type::Sprite(0), Type::U8, Type::U8], Type::Bool),
+            Self::BeginDrawBatch => (vec![], Type::Unit),
+            Self::EndDrawBatch => (vec![], Type::Unit),
             Self::WaitKey => (vec![], Type::U8),
             Self::IsKeyPressed => (vec![Type::U8], Type::Bool),
+            Self::IsKeyJustPressed => (vec![Type::U8], Type::Bool),
             Self::Delay => (vec![], Type::U8),
             Self::SetDelay => (vec![Type::U8], Type::Unit),
             Self::SetSound => (vec![Type::U8], Type::Unit),

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -262,6 +262,19 @@ fn test_sprite_and_draw() {
 }
 
 #[test]
+fn test_custom_draw_batch_and_key_edge_builtins() {
+    analyze_ok(
+        "
+        fn main() -> () {
+            begin_draw_batch();
+            let rotate: bool = is_key_just_pressed(5);
+            end_draw_batch();
+        }
+    ",
+    );
+}
+
+#[test]
 fn test_assign_type_mismatch() {
     analyze_err_matches(
         "

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -139,6 +139,29 @@ fn test_sprite_and_draw() {
 }
 
 #[test]
+fn test_custom_batch_and_key_edge_codegen() {
+    let bytes = compile(
+        "fn main() -> () {
+            begin_draw_batch();
+            let rotate: bool = is_key_just_pressed(5);
+            end_draw_batch();
+        }",
+    );
+    assert!(
+        bytes.chunks(2).any(|w| w == [0x00, 0xF0]),
+        "expected custom begin draw batch opcode"
+    );
+    assert!(
+        bytes.chunks(2).any(|w| w == [0xE0, 0x9F] || (w[0] & 0xF0) == 0xE0 && w[1] == 0x9F),
+        "expected custom just-pressed opcode"
+    );
+    assert!(
+        bytes.chunks(2).any(|w| w == [0x00, 0xF1]),
+        "expected custom end draw batch opcode"
+    );
+}
+
+#[test]
 fn test_if_generates_skip_and_jp() {
     let bytes = compile(
         "fn main() -> () {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -236,6 +236,21 @@ fn test_function_call() {
 }
 
 #[test]
+fn test_custom_builtins_parse() {
+    let prog = parse("fn f() -> () { begin_draw_batch(); end_draw_batch(); let r: bool = is_key_just_pressed(5); }");
+    match &prog.top_levels[0] {
+        TopLevel::FnDef { body, .. } => {
+            if let ExprKind::Block { stmts, .. } = &body.kind {
+                assert_eq!(stmts.len(), 3);
+            } else {
+                panic!("expected Block");
+            }
+        }
+        _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
 fn test_let_stmt() {
     let prog = parse("fn f() -> () { let x: u8 = 42; }");
     match &prog.top_levels[0] {


### PR DESCRIPTION
## Summary
- add `begin_draw_batch()` / `end_draw_batch()` builtins and custom opcode encoding
- add `is_key_just_pressed()` as a one-shot key builtin
- cover parser, analyzer, opcode, and codegen behavior with tests

## Verification
- cargo test --quiet