### PR TITLE
perf: match jump table and inline expansion (#62)

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -779,6 +779,18 @@ impl CodeGen {
             && (meta.is_leaf || meta.callees.len() == 1)
     }
 
+    /// 現在のレジスタ使用状況でインライン展開が安全かを判定
+    fn can_inline_here(&self, name: &str) -> bool {
+        if !self.should_inline(name) {
+            return false;
+        }
+        let Some(meta) = self.fn_meta.get(name) else {
+            return false;
+        };
+        // caller の next_free_reg + callee の estimated_max_reg が V14 以内か
+        self.next_free_reg + meta.estimated_max_reg <= 15
+    }
+
     /// 式中のユーザー定義関数呼び出しを再帰的に収集
     fn collect_callees(expr: &Expr, fn_names: &HashSet<String>, out: &mut HashSet<String>) {
         match &expr.kind {
@@ -1630,7 +1642,7 @@ impl CodeGen {
                 }
             }
             ExprKind::BuiltinCall { builtin, args } => self.codegen_builtin_call(*builtin, args),
-            ExprKind::Call { name, args } if self.should_inline(name) => {
+            ExprKind::Call { name, args } if self.can_inline_here(name) => {
                 self.codegen_inline_call(name, args)
             }
             ExprKind::Call { name, args } => {

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -293,7 +293,6 @@ fn test_match_non_consecutive_generates_se_jp() {
         bytes.chunks(2).any(|c| c[0] & 0xF0 == 0x30),
         "expected SE instruction in match codegen (fallback)"
     );
-    // ジャンプテーブルは使われない
     assert!(
         !bytes.chunks(2).any(|c| c[0] & 0xF0 == 0xB0),
         "should not use JpV0 for non-consecutive patterns"


### PR DESCRIPTION
## Summary
- **ジャンプテーブル最適化**: match 式の連続整数パターン (0, 1, 2, ...) を `JpV0 (BNNN)` によるジャンプテーブルに変換。SE+JP の線形探索 O(n) → O(1) に削減。`draw_piece` の 28-arm match で ~75 命令/call × 最大 4 回/tick = ~300 命令削減が見込まれる
- **インライン展開拡大**: 閾値を `is_leaf && nodes≤15` → `nodes≤30 && (is_leaf || callees==1)` に緩和。非リーフ小関数もインライン対象にすることで caller-save オーバーヘッドを削減 (~24 命令/tick)

## Test plan
- [x] `cargo test` — 全 86 テスト通過
- [x] `cargo clippy` — lint 通過
- [x] `cargo fmt --check` — フォーマット通過
- [x] 連続整数パターン match で BNNN が出力されることを確認するテスト追加
- [x] 非連続パターンで SE+JP フォールバックが使われることを確認するテスト追加
- [x] enum match でもジャンプテーブルが適用されることを確認
- [ ] TETRIS ROM をコンパイルし、ROM サイズが 3584 bytes 以下であること
- [ ] chip8-ts で TETRIS を実行し、操作可能な速度でプレイできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)