### PR TITLE
fix: protect variable registers from in-place ops in let bindings

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1420,6 +1420,16 @@ impl CodeGen {
                         _ => {}
                     }
 
+                    // else ブランチの結果を then ブランチの結果レジスタに合わせる
+                    if !then_is_struct
+                        && !else_is_struct
+                        && let (ValueLocation::InRegister(tr), ValueLocation::InRegister(er)) =
+                            (&then_loc, &else_loc)
+                        && tr != er
+                    {
+                        self.emit_op(Opcode::LdReg(*tr, *er));
+                    }
+
                     let end_addr = self.current_addr();
                     self.patch_at(jp_end_offset, Opcode::Jp(end_addr));
 
@@ -1427,8 +1437,8 @@ impl CodeGen {
                         _ if then_is_struct || else_is_struct => {
                             ValueLocation::InRegister(Register::V0)
                         }
-                        (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         (ValueLocation::InRegister(r), _) => ValueLocation::InRegister(r),
+                        (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         _ => ValueLocation::Void,
                     }
                 } else {
@@ -1569,6 +1579,17 @@ impl CodeGen {
                 let Some(rhs_reg) = self.codegen_expr(rhs).register() else {
                     return ValueLocation::Void;
                 };
+                // Add/Sub/And/Or は lhs_reg を直接変更するため、
+                // 変数レジスタならテンポラリにコピーして保護する (issue #66)
+                let lhs_reg = if matches!(op, BinOp::Add | BinOp::Sub | BinOp::And | BinOp::Or)
+                    && self.is_variable_register(lhs_reg)
+                {
+                    let tmp = self.alloc_temp_register();
+                    self.emit_op(Opcode::LdReg(tmp.into(), lhs_reg));
+                    Register::from(tmp)
+                } else {
+                    lhs_reg
+                };
                 let result_reg = lhs_reg;
                 match op {
                     BinOp::Add => {
@@ -1708,10 +1729,18 @@ impl CodeGen {
                         ValueLocation::InRegister(zero.into())
                     }
                     UnaryOp::Not => {
+                        // 変数レジスタを直接演算で破壊しないようテンポラリにコピー (issue #66)
+                        let tmp = if self.is_variable_register(reg) {
+                            let t = self.alloc_temp_register();
+                            self.emit_op(Opcode::LdReg(t.into(), reg));
+                            t.into()
+                        } else {
+                            reg
+                        };
                         let one = self.alloc_temp_register();
                         self.emit_op(Opcode::LdImm(one.into(), 0x01));
-                        self.emit_op(Opcode::Xor(reg, one.into()));
-                        ValueLocation::InRegister(reg)
+                        self.emit_op(Opcode::Xor(tmp, one.into()));
+                        ValueLocation::InRegister(tmp)
                     }
                 }
             }
@@ -1957,6 +1986,17 @@ impl CodeGen {
                         _ => {}
                     }
 
+                    // else ブランチの結果を then ブランチの結果レジスタに合わせる
+                    // (スカラーで結果レジスタが異なる場合)
+                    if !then_is_struct
+                        && !else_is_struct
+                        && let (ValueLocation::InRegister(tr), ValueLocation::InRegister(er)) =
+                            (&then_loc, &else_loc)
+                        && tr != er
+                    {
+                        self.emit_op(Opcode::LdReg(*tr, *er));
+                    }
+
                     let end_addr = self.current_addr();
                     self.patch_at(jp_end_offset, Opcode::Jp(end_addr));
 
@@ -1964,8 +2004,8 @@ impl CodeGen {
                         _ if then_is_struct || else_is_struct => {
                             ValueLocation::InRegister(Register::V0)
                         }
-                        (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         (ValueLocation::InRegister(r), _) => ValueLocation::InRegister(r),
+                        (_, ValueLocation::InRegister(r)) => ValueLocation::InRegister(r),
                         _ => ValueLocation::Void,
                     }
                 } else {

--- a/tests/codegen_tests.rs
+++ b/tests/codegen_tests.rs
@@ -1656,3 +1656,51 @@ fn test_run_issue64_sub_does_not_corrupt_variable() {
         20 // b = x = 20, not 17
     );
 }
+
+#[test]
+fn test_run_issue66_let_add_does_not_corrupt_variable() {
+    // let ny = y + 1 で y が破壊されないこと
+    assert_eq!(
+        compile_and_run(
+            "fn check(a: u8, b: u8) -> u8 { a }
+             fn main() -> u8 {
+               let y: u8 = 10;
+               let ny: u8 = y + 1;
+               check(y, ny)
+             }"
+        ),
+        10 // y = 10, not 11
+    );
+}
+
+#[test]
+fn test_run_issue66_let_sub_does_not_corrupt_variable() {
+    // let ny = y - 1 で y が破壊されないこと
+    assert_eq!(
+        compile_and_run(
+            "fn check(a: u8, b: u8) -> u8 { a }
+             fn main() -> u8 {
+               let y: u8 = 10;
+               let ny: u8 = y - 1;
+               check(y, ny)
+             }"
+        ),
+        10 // y = 10, not 9
+    );
+}
+
+#[test]
+fn test_run_issue66_not_does_not_corrupt_variable() {
+    // let b = !flag で flag が破壊されないこと
+    assert_eq!(
+        compile_and_run(
+            "fn to_u8(x: bool) -> u8 { if x { 1 } else { 0 } }
+             fn main() -> u8 {
+               let flag: bool = true;
+               let b: bool = !flag;
+               to_u8(flag)
+             }"
+        ),
+        1 // flag = true (1), not false (0)
+    );
+}


### PR DESCRIPTION
## Summary

- `let ny = y + 1` 等の let 束縛で、`Add`/`Sub`/`And`/`Or` が LHS の変数レジスタを直接変更して元の変数を破壊していた問題を修正
- `UnaryOp::Not` (`Xor`) も同様に変数レジスタを破壊する問題を修正
- if-else ブランチ間で結果レジスタが異なる場合に正規化する `LdReg` を追加 (TCO パスも含む)

Closes #66

## Test plan

- [x] `cargo test` — 全 91 codegen テスト + 他全テスト通過
- [x] `cargo clippy` — 警告なし
- [x] `cargo fmt --check` — フォーマット問題なし
- [x] 新規回帰テスト 3 件追加:
  - `test_run_issue66_let_add_does_not_corrupt_variable`
  - `test_run_issue66_let_sub_does_not_corrupt_variable`
  - `test_run_issue66_not_does_not_corrupt_variable`
- [x] 既存テスト `test_run_issue64_*` が引き続き通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)