### PR TITLE
refactor: 識別子に newtype を導入し HashMap<String, ...> を型安全にする

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::lexer::token::Span;
+use crate::names::{FieldName, FunctionName, TypeName, VariableName, VariantName};
 use crate::parser::ast::*;
 
 /// UserRegister の総数 (V0-VE)
@@ -16,9 +17,9 @@ pub enum AnalyzeErrorKind {
     /// main 関数が定義されていない
     MissingMain,
     /// 未定義の変数を参照
-    UndefinedVariable(String),
+    UndefinedVariable(VariableName),
     /// 未定義の関数を呼び出し
-    UndefinedFunction(String),
+    UndefinedFunction(FunctionName),
     /// 型の不一致 (context は "in let", "return type" など文脈を示す)
     TypeMismatch {
         context: &'static str,
@@ -29,13 +30,13 @@ pub enum AnalyzeErrorKind {
     BinaryOpTypeMismatch { lhs: Type, rhs: Type },
     /// ユーザー定義関数の引数の数が合わない
     ArgumentCountMismatch {
-        function: String,
+        function: FunctionName,
         expected: usize,
         found: usize,
     },
     /// ユーザー定義関数の引数の型が合わない
     ArgumentTypeMismatch {
-        function: String,
+        function: FunctionName,
         expected: Type,
         found: Type,
     },
@@ -82,33 +83,42 @@ pub enum AnalyzeErrorKind {
     /// match アームが空
     MatchNoArms,
     /// 未定義の enum
-    UndefinedEnum(String),
+    UndefinedEnum(TypeName),
     /// 未定義の enum variant
-    UndefinedEnumVariant { enum_name: String, variant: String },
+    UndefinedEnumVariant {
+        enum_name: TypeName,
+        variant: VariantName,
+    },
     /// match の enum 網羅性不足
     NonExhaustiveMatch {
-        enum_name: String,
-        missing: Vec<String>,
+        enum_name: TypeName,
+        missing: Vec<VariantName>,
     },
     /// 不明な型名
-    UnknownType(String),
+    UnknownType(TypeName),
     /// random_enum の引数が enum 名でない
-    RandomEnumArgNotEnum(String),
+    RandomEnumArgNotEnum(VariableName),
     /// 未定義の struct
-    UndefinedStruct(String),
+    UndefinedStruct(TypeName),
     /// 未定義のフィールド
-    UndefinedField { struct_name: String, field: String },
+    UndefinedField {
+        struct_name: TypeName,
+        field: FieldName,
+    },
     /// struct リテラルで必須フィールドが不足
     MissingFields {
-        struct_name: String,
-        missing: Vec<String>,
+        struct_name: TypeName,
+        missing: Vec<FieldName>,
     },
     /// struct リテラルでフィールドが重複
-    DuplicateField { struct_name: String, field: String },
+    DuplicateField {
+        struct_name: TypeName,
+        field: FieldName,
+    },
     /// フィールドアクセスの対象が struct でない
     FieldAccessOnNonStruct(Type),
     /// イミュータブル変数への代入
-    ImmutableAssignment(String),
+    ImmutableAssignment(VariableName),
 }
 
 /// 意味解析エラー
@@ -217,7 +227,11 @@ impl std::fmt::Display for AnalyzeError {
             AnalyzeErrorKind::NonExhaustiveMatch { enum_name, missing } => write!(
                 f,
                 "non-exhaustive match on '{enum_name}': missing {}",
-                missing.join(", ")
+                missing
+                    .iter()
+                    .map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             AnalyzeErrorKind::UnknownType(name) => write!(f, "unknown type: '{name}'"),
             AnalyzeErrorKind::RandomEnumArgNotEnum(name) => {
@@ -235,7 +249,11 @@ impl std::fmt::Display for AnalyzeError {
             } => write!(
                 f,
                 "missing fields in struct '{struct_name}': {}",
-                missing.join(", ")
+                missing
+                    .iter()
+                    .map(|f| f.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             AnalyzeErrorKind::DuplicateField { struct_name, field } => {
                 write!(f, "duplicate field '{field}' in struct '{struct_name}'")
@@ -260,17 +278,17 @@ struct FnSig {
 /// 意味解析器
 pub struct Analyzer {
     /// グローバル変数の型
-    globals: HashMap<String, Type>,
+    globals: HashMap<VariableName, Type>,
     /// ミュータブルなグローバル変数の名前
-    mutable_globals: HashSet<String>,
+    mutable_globals: HashSet<VariableName>,
     /// ユーザー定義関数のシグネチャ
-    functions: HashMap<String, FnSig>,
+    functions: HashMap<FunctionName, FnSig>,
     /// ユーザー定義 enum (名前 → variant リスト)
-    enums: HashMap<String, Vec<String>>,
+    enums: HashMap<TypeName, Vec<VariantName>>,
     /// ユーザー定義 struct (名前 → フィールド定義リスト)
-    structs: HashMap<String, Vec<StructField>>,
+    structs: HashMap<TypeName, Vec<StructField>>,
     /// ローカルスコープスタック
-    locals: Vec<HashMap<String, Type>>,
+    locals: Vec<HashMap<VariableName, Type>>,
     /// 現在の関数の戻り値型
     current_return_type: Option<Type>,
     /// loop のネスト深さ
@@ -452,7 +470,7 @@ impl Analyzer {
         }
     }
 
-    fn insert_local(&mut self, name: String, ty: Type) {
+    fn insert_local(&mut self, name: VariableName, ty: Type) {
         if let Some(scope) = self.locals.last_mut() {
             scope.insert(name, ty);
         }
@@ -487,7 +505,7 @@ impl Analyzer {
             ExprKind::IntLiteral(_) => Some(Type::U8),
             ExprKind::BoolLiteral(_) => Some(Type::Bool),
             ExprKind::Ident(name) => {
-                if let Some(ty) = self.lookup_var(name) {
+                if let Some(ty) = self.lookup_var(name.as_str()) {
                     Some(ty)
                 } else {
                     self.errors.push(AnalyzeError {
@@ -575,8 +593,8 @@ impl Analyzer {
                         return None;
                     }
                     if let ExprKind::Ident(name) = &args[0].kind {
-                        if self.enums.contains_key(name) {
-                            return Some(Type::UserType(name.clone()));
+                        if self.enums.contains_key(name.as_str()) {
+                            return Some(Type::UserType(TypeName::new(name.as_str())));
                         } else {
                             self.errors.push(AnalyzeError {
                                 kind: AnalyzeErrorKind::RandomEnumArgNotEnum(name.clone()),
@@ -586,9 +604,9 @@ impl Analyzer {
                         }
                     } else {
                         self.errors.push(AnalyzeError {
-                            kind: AnalyzeErrorKind::RandomEnumArgNotEnum(
-                                "<non-identifier>".to_string(),
-                            ),
+                            kind: AnalyzeErrorKind::RandomEnumArgNotEnum(VariableName::new(
+                                "<non-identifier>",
+                            )),
                             span: expr.span,
                         });
                         return None;
@@ -764,7 +782,7 @@ impl Analyzer {
                 if let Some(Type::UserType(ref enum_name)) = scr_ty
                     && let Some(all_variants) = self.enums.get(enum_name).cloned()
                 {
-                    let covered: Vec<String> = arms
+                    let covered: Vec<VariantName> = arms
                         .iter()
                         .filter_map(|arm| {
                             if let ExprKind::EnumVariant { variant, .. } = &arm.pattern.kind {
@@ -774,7 +792,7 @@ impl Analyzer {
                             }
                         })
                         .collect();
-                    let missing: Vec<String> = all_variants
+                    let missing: Vec<VariantName> = all_variants
                         .into_iter()
                         .filter(|v| !covered.contains(v))
                         .collect();
@@ -860,7 +878,7 @@ impl Analyzer {
                     }
                     // base なしの場合、全フィールドが指定されているかチェック
                     if base.is_none() {
-                        let missing: Vec<String> = struct_fields
+                        let missing: Vec<FieldName> = struct_fields
                             .iter()
                             .filter(|f| !seen.contains(&f.name))
                             .map(|f| f.name.clone())
@@ -998,12 +1016,12 @@ impl Analyzer {
                 self.insert_local(name.clone(), ty.clone());
             }
             StmtKind::Assign { name, value } => {
-                let var_ty = self.lookup_var(name);
+                let var_ty = self.lookup_var(name.as_str());
                 let val_ty = self.type_check_expr(value);
                 // グローバル変数への代入は mutable でなければエラー
-                let is_global = self.globals.contains_key(name)
-                    && !self.locals.iter().any(|s| s.contains_key(name));
-                if is_global && !self.mutable_globals.contains(name) {
+                let is_global = self.globals.contains_key(name.as_str())
+                    && !self.locals.iter().any(|s| s.contains_key(name.as_str()));
+                if is_global && !self.mutable_globals.contains(name.as_str()) {
                     self.errors.push(AnalyzeError {
                         kind: AnalyzeErrorKind::ImmutableAssignment(name.clone()),
                         span: stmt.span,
@@ -1035,7 +1053,7 @@ impl Analyzer {
                 index,
                 value,
             } => {
-                let arr_ty = self.lookup_var(array);
+                let arr_ty = self.lookup_var(array.as_str());
                 // 配列型チェック
                 if let Some(ref ty) = arr_ty {
                     if !matches!(ty, Type::Array { .. }) {
@@ -1062,9 +1080,9 @@ impl Analyzer {
                 // 値の型チェック
                 self.type_check_expr(value);
                 // mutable チェック
-                let is_global = self.globals.contains_key(array)
-                    && !self.locals.iter().any(|s| s.contains_key(array));
-                if is_global && !self.mutable_globals.contains(array) {
+                let is_global = self.globals.contains_key(array.as_str())
+                    && !self.locals.iter().any(|s| s.contains_key(array.as_str()));
+                if is_global && !self.mutable_globals.contains(array.as_str()) {
                     self.errors.push(AnalyzeError {
                         kind: AnalyzeErrorKind::ImmutableAssignment(array.clone()),
                         span: stmt.span,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::chip8::{Addr, ByteOffset, Opcode, Register, SpriteHeight, UserRegister};
+use crate::names::{FieldName, FunctionName, TypeName, VariableName, VariantName};
 use crate::parser::ast::*;
 
 /// CHIP-8 命令のバイト数
@@ -12,10 +13,10 @@ enum ValueLocation {
     /// 値はレジスタに格納されている
     InRegister(Register),
     /// struct の値: メモリに格納 (アドレスと struct 名)
-    InMemory { addr: u16, struct_name: String },
+    InMemory { addr: u16, struct_name: TypeName },
     /// struct の値: 連続レジスタに保持
     InRegisters {
-        struct_name: String,
+        struct_name: TypeName,
         base_reg: UserRegister,
         field_count: u8,
     },
@@ -46,9 +47,9 @@ struct ForwardRef {
 #[derive(Debug)]
 enum ForwardRefKind {
     /// 関数呼び出し (CALL addr)
-    Call(String),
+    Call(FunctionName),
     /// グローバル変数のアドレス (LD I, addr)
-    GlobalAddr(String),
+    GlobalAddr(VariableName),
 }
 
 /// ローカル変数のバインディング情報
@@ -57,10 +58,10 @@ enum LocalBinding {
     /// スカラー値 (u8, bool, enum)
     Single(UserRegister),
     /// struct 値: メモリに格納 (アドレスと struct 名)
-    StructInMemory { addr: u16, struct_name: String },
+    StructInMemory { addr: u16, struct_name: TypeName },
     /// struct 値: 連続レジスタに保持 (base_reg から field_count 個)
     StructInRegisters {
-        struct_name: String,
+        struct_name: TypeName,
         base_reg: UserRegister,
         field_count: u8,
     },
@@ -70,7 +71,7 @@ enum LocalBinding {
 #[derive(Debug, Clone)]
 struct FunctionMeta {
     /// 呼び出すユーザー定義関数のリスト
-    callees: HashSet<String>,
+    callees: HashSet<FunctionName>,
     /// 他のユーザー定義関数を呼ばない (callees が空)
     is_leaf: bool,
     /// パラメータのフラット化レジスタ数 (struct レジスタ保持最適化で使用予定)
@@ -92,29 +93,29 @@ pub struct CodeGen {
     /// データセクション (スプライトなど)
     data: Vec<u8>,
     /// 関数名 → 確定アドレス
-    fn_addrs: HashMap<String, Addr>,
+    fn_addrs: HashMap<FunctionName, Addr>,
     /// グローバル変数名 → データセクション内のバイトオフセット (Pass 1 で記録)
-    data_offsets: HashMap<String, u16>,
+    data_offsets: HashMap<VariableName, u16>,
     /// グローバル変数名 → 最終解決済みアドレス (generate() 末尾で確定)
-    resolved_addrs: HashMap<String, Addr>,
+    resolved_addrs: HashMap<VariableName, Addr>,
     /// グローバル変数のスプライトサイズ (バイト数)
-    sprite_sizes: HashMap<String, usize>,
+    sprite_sizes: HashMap<VariableName, usize>,
     /// enum variant → u8 値
-    enum_variant_values: HashMap<(String, String), u8>,
+    enum_variant_values: HashMap<(TypeName, VariantName), u8>,
     /// ミュータブルグローバル変数
-    mutable_globals: HashSet<String>,
+    mutable_globals: HashSet<VariableName>,
     /// struct 定義 (名前 → フィールド定義リスト)
-    struct_defs: HashMap<String, Vec<StructField>>,
+    struct_defs: HashMap<TypeName, Vec<StructField>>,
     /// 関数の戻り値型 (struct 戻り値のメモリ化に使用)
-    fn_return_types: HashMap<String, Type>,
+    fn_return_types: HashMap<FunctionName, Type>,
     /// 関数ごとの最適化メタデータ (コールグラフ解析結果)
-    fn_meta: HashMap<String, FunctionMeta>,
+    fn_meta: HashMap<FunctionName, FunctionMeta>,
     /// 関数の AST 本体 (インライン展開用)
-    fn_bodies: HashMap<String, (Vec<Param>, Expr)>,
+    fn_bodies: HashMap<FunctionName, (Vec<Param>, Expr)>,
     /// メモリスロット割り当て用の次のアドレス (struct データ + caller-save 共用)
     next_save_slot: u16,
     /// ローカル変数名 → 割り当て済みバインディング
-    local_bindings: HashMap<String, LocalBinding>,
+    local_bindings: HashMap<VariableName, LocalBinding>,
     /// 次に割り当て可能なレジスタ番号
     next_free_reg: u8,
     /// ローカル変数にバインド済みのレジスタ数 (一時レジスタのリセット基準)
@@ -124,7 +125,7 @@ pub struct CodeGen {
     /// ループごとの break 先パッチオフセットのスタック
     loop_break_offsets: Vec<Vec<ByteOffset>>,
     /// 現在コード生成中の関数名 (TCO 検出用)
-    current_fn_name: Option<String>,
+    current_fn_name: Option<FunctionName>,
     /// 現在の関数の先頭アドレス (TCO ジャンプ先)
     current_fn_start_addr: Option<Addr>,
     /// 現在の関数のパラメータ数 (TCO 引数コピー用)
@@ -371,7 +372,7 @@ impl CodeGen {
                         }
                     }
                 }
-                if self.current_fn_name.as_deref() == Some("main") {
+                if self.current_fn_name.as_ref().map(|n| n.as_str()) == Some("main") {
                     // main は JP で呼ばれるため RET ではなくセルフループで停止
                     let halt_addr = self.current_addr();
                     self.emit_op(Opcode::Jp(halt_addr));
@@ -499,7 +500,10 @@ impl CodeGen {
                 flat_args[j] == target && flat_args[j] != target_j
             });
             if will_be_read_later {
-                assert!(next_tmp <= 14, "not enough temp registers for parallel move");
+                assert!(
+                    next_tmp <= 14,
+                    "not enough temp registers for parallel move"
+                );
                 let tmp: Register = UserRegister::new(next_tmp).into();
                 next_tmp += 1;
                 self.emit_op(Opcode::LdReg(tmp, target));
@@ -537,7 +541,7 @@ impl CodeGen {
     }
 
     /// 式中で参照されている変数名を収集する。
-    fn collect_referenced_vars(expr: &Expr, out: &mut HashSet<String>) {
+    fn collect_referenced_vars(expr: &Expr, out: &mut HashSet<VariableName>) {
         match &expr.kind {
             ExprKind::Ident(name) => {
                 out.insert(name.clone());
@@ -561,7 +565,7 @@ impl CodeGen {
         }
     }
 
-    fn lookup_binding(&self, name: &str) -> Option<&LocalBinding> {
+    fn lookup_binding(&self, name: &VariableName) -> Option<&LocalBinding> {
         self.local_bindings.get(name)
     }
 
@@ -570,7 +574,7 @@ impl CodeGen {
     }
 
     /// struct のフラット化フィールド数を計算
-    fn struct_field_count(&self, struct_name: &str) -> usize {
+    fn struct_field_count(&self, struct_name: &TypeName) -> usize {
         if let Some(fields) = self.struct_defs.get(struct_name) {
             fields
                 .iter()
@@ -589,11 +593,11 @@ impl CodeGen {
     }
 
     /// struct 内のフィールドのレジスタオフセットを計算
-    fn struct_field_offset(&self, struct_name: &str, field_name: &str) -> Option<usize> {
+    fn struct_field_offset(&self, struct_name: &TypeName, field_name: &FieldName) -> Option<usize> {
         let fields = self.struct_defs.get(struct_name)?;
         let mut offset = 0;
         for f in fields {
-            if f.name == field_name {
+            if f.name == *field_name {
                 return Some(offset);
             }
             if let Type::UserType(ref name) = f.ty
@@ -608,23 +612,23 @@ impl CodeGen {
     }
 
     /// struct のフィールドの型を取得
-    fn struct_field_type(&self, struct_name: &str, field_name: &str) -> Option<Type> {
+    fn struct_field_type(&self, struct_name: &TypeName, field_name: &FieldName) -> Option<Type> {
         let fields = self.struct_defs.get(struct_name)?;
         fields
             .iter()
-            .find(|f| f.name == field_name)
+            .find(|f| f.name == *field_name)
             .map(|f| f.ty.clone())
     }
 
-    fn emit_ld_i_global(&mut self, name: &str) {
+    fn emit_ld_i_global(&mut self, name: &VariableName) {
         let offset = self.emit_placeholder();
         self.forward_refs.push(ForwardRef {
             offset,
-            kind: ForwardRefKind::GlobalAddr(name.to_string()),
+            kind: ForwardRefKind::GlobalAddr(name.clone()),
         });
     }
 
-    fn emit_global_read(&mut self, target_reg: Register, name: &str) {
+    fn emit_global_read(&mut self, target_reg: Register, name: &VariableName) {
         if target_reg == Register::V0 {
             self.emit_ld_i_global(name);
             self.emit_op(Opcode::LdVxI(Register::V0));
@@ -642,7 +646,7 @@ impl CodeGen {
         }
     }
 
-    fn emit_global_write(&mut self, name: &str, src_reg: Register) {
+    fn emit_global_write(&mut self, name: &VariableName, src_reg: Register) {
         if src_reg == Register::V0 {
             self.emit_ld_i_global(name);
             self.emit_op(Opcode::LdIVx(Register::V0));
@@ -807,7 +811,7 @@ impl CodeGen {
     /// AST を走査して関数ごとのメタデータを構築する
     fn analyze_call_graph(&mut self, program: &Program) {
         // 全関数名を収集 (ユーザー定義関数の判定用)
-        let fn_names: HashSet<String> = program
+        let fn_names: HashSet<FunctionName> = program
             .top_levels
             .iter()
             .filter_map(|top| {
@@ -864,8 +868,8 @@ impl CodeGen {
     }
 
     /// インライン展開すべきかどうかを判定
-    fn should_inline(&self, name: &str) -> bool {
-        if name == "main" {
+    fn should_inline(&self, name: &FunctionName) -> bool {
+        if name.as_str() == "main" {
             return false;
         }
         let Some(meta) = self.fn_meta.get(name) else {
@@ -879,7 +883,7 @@ impl CodeGen {
     }
 
     /// 現在のレジスタ使用状況でインライン展開が安全かを判定
-    fn can_inline_here(&self, name: &str) -> bool {
+    fn can_inline_here(&self, name: &FunctionName) -> bool {
         if !self.should_inline(name) {
             return false;
         }
@@ -891,7 +895,11 @@ impl CodeGen {
     }
 
     /// 式中のユーザー定義関数呼び出しを再帰的に収集
-    fn collect_callees(expr: &Expr, fn_names: &HashSet<String>, out: &mut HashSet<String>) {
+    fn collect_callees(
+        expr: &Expr,
+        fn_names: &HashSet<FunctionName>,
+        out: &mut HashSet<FunctionName>,
+    ) {
         match &expr.kind {
             ExprKind::Call { name, args } => {
                 if fn_names.contains(name) {
@@ -969,7 +977,11 @@ impl CodeGen {
     }
 
     /// 文中のユーザー定義関数呼び出しを再帰的に収集
-    fn collect_callees_stmt(stmt: &Stmt, fn_names: &HashSet<String>, out: &mut HashSet<String>) {
+    fn collect_callees_stmt(
+        stmt: &Stmt,
+        fn_names: &HashSet<FunctionName>,
+        out: &mut HashSet<FunctionName>,
+    ) {
         match &stmt.kind {
             StmtKind::Let { value, .. } => Self::collect_callees(value, fn_names, out),
             StmtKind::Assign { value, .. } => Self::collect_callees(value, fn_names, out),
@@ -1192,7 +1204,7 @@ impl CodeGen {
     ///
     /// CALL/RET + caller-save/restore を完全に省略し、
     /// callee の本体を caller のコンテキストに直接埋め込む。
-    fn codegen_inline_call(&mut self, name: &str, args: &[Expr]) -> ValueLocation {
+    fn codegen_inline_call(&mut self, name: &FunctionName, args: &[Expr]) -> ValueLocation {
         let (params, body) = self.fn_bodies.get(name).unwrap().clone();
 
         // 1. 引数を評価 (caller のコンテキストで)
@@ -1200,7 +1212,7 @@ impl CodeGen {
         // 保護する。式引数の評価が元の変数レジスタを破壊しても、先に評価済みの
         // 引数値が影響を受けないようにする。(issue #64)
         let has_expr_args = args.iter().any(|a| !Self::is_safe_arg(a));
-        let mut arg_locs: Vec<(String, Type, ValueLocation)> = Vec::new();
+        let mut arg_locs: Vec<(VariableName, Type, ValueLocation)> = Vec::new();
         for (i, (param, arg)) in params.iter().zip(args.iter()).enumerate() {
             let loc = self.codegen_expr(arg);
             let needs_protect = if has_expr_args {
@@ -1341,7 +1353,7 @@ impl CodeGen {
     fn codegen_expr_tail(&mut self, expr: &Expr) -> ValueLocation {
         match &expr.kind {
             // 末尾位置での自己再帰呼び出し → TCO
-            ExprKind::Call { name, args } if self.current_fn_name.as_deref() == Some(name) => {
+            ExprKind::Call { name, args } if self.current_fn_name.as_ref() == Some(name) => {
                 let fn_start = self.current_fn_start_addr.unwrap();
                 let param_count = self.current_fn_param_count;
 
@@ -2323,9 +2335,9 @@ impl CodeGen {
     fn codegen_struct_equality_memory(
         &mut self,
         l_addr: u16,
-        l_name: &str,
+        l_name: &TypeName,
         r_addr: u16,
-        _r_name: &str,
+        _r_name: &TypeName,
         is_eq: bool,
     ) -> ValueLocation {
         let count = self.struct_field_count(l_name);
@@ -2483,7 +2495,7 @@ impl CodeGen {
             BuiltinFunction::RandomEnum => {
                 // args[0] は Ident(enum_name)
                 let enum_name = if let ExprKind::Ident(name) = &args[0].kind {
-                    name.clone()
+                    TypeName::new(name.as_str())
                 } else {
                     return ValueLocation::Void;
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,7 @@ pub mod codegen;
 pub mod emitter;
 /// ソースコードからトークン列への字句解析
 pub mod lexer;
+/// 識別子の newtype (関数名・変数名・型名・フィールド名・バリアント名)
+pub mod names;
 /// トークン列から AST への構文解析
 pub mod parser;

--- a/src/names.rs
+++ b/src/names.rs
@@ -1,0 +1,96 @@
+//! 識別子の newtype 定義
+//!
+//! コンパイラ内部で使用される識別子を型レベルで区別し、
+//! 関数名・変数名・型名・フィールド名・バリアント名の混同をコンパイル時に検出する。
+
+use std::borrow::Borrow;
+use std::fmt;
+
+macro_rules! define_name_type {
+    ($(#[doc = $doc:expr])* $name:ident) => {
+        $(#[doc = $doc])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(name: impl Into<String>) -> Self {
+                Self(name.into())
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_owned())
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+    };
+}
+
+define_name_type! {
+    /// ユーザー定義関数の名前
+    FunctionName
+}
+
+define_name_type! {
+    /// 変数の名前 (グローバル・ローカル・パラメータ)
+    VariableName
+}
+
+define_name_type! {
+    /// ユーザー定義型の名前 (enum・struct)
+    TypeName
+}
+
+define_name_type! {
+    /// struct フィールドの名前
+    FieldName
+}
+
+define_name_type! {
+    /// enum バリアントの名前
+    VariantName
+}

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,4 +1,5 @@
 use crate::lexer::token::Span;
+use crate::names::{FieldName, FunctionName, TypeName, VariableName, VariantName};
 
 /// 型
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -8,7 +9,7 @@ pub enum Type {
     Unit,
     Array(Box<Type>, usize),
     Sprite(usize),
-    UserType(String),
+    UserType(TypeName),
 }
 
 /// 二項演算子
@@ -47,7 +48,7 @@ pub struct Expr {
 pub enum ExprKind {
     IntLiteral(u64),
     BoolLiteral(bool),
-    Ident(String),
+    Ident(VariableName),
     BinaryOp {
         op: BinOp,
         lhs: Box<Expr>,
@@ -58,7 +59,7 @@ pub enum ExprKind {
         expr: Box<Expr>,
     },
     Call {
-        name: String,
+        name: FunctionName,
         args: Vec<Expr>,
     },
     BuiltinCall {
@@ -88,17 +89,17 @@ pub enum ExprKind {
         arms: Vec<MatchArm>,
     },
     EnumVariant {
-        enum_name: String,
-        variant: String,
+        enum_name: TypeName,
+        variant: VariantName,
     },
     StructLiteral {
-        name: String,
-        fields: Vec<(String, Expr)>,
+        name: TypeName,
+        fields: Vec<(FieldName, Expr)>,
         base: Option<Box<Expr>>,
     },
     FieldAccess {
         expr: Box<Expr>,
-        field: String,
+        field: FieldName,
     },
 }
 
@@ -119,16 +120,16 @@ pub struct Stmt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StmtKind {
     Let {
-        name: String,
+        name: VariableName,
         ty: Type,
         value: Expr,
     },
     Assign {
-        name: String,
+        name: VariableName,
         value: Expr,
     },
     IndexAssign {
-        array: String,
+        array: VariableName,
         index: Expr,
         value: Expr,
     },
@@ -140,14 +141,14 @@ pub enum StmtKind {
 /// struct のフィールド定義
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructField {
-    pub name: String,
+    pub name: FieldName,
     pub ty: Type,
 }
 
 /// 関数の引数
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Param {
-    pub name: String,
+    pub name: VariableName,
     pub ty: Type,
 }
 
@@ -155,26 +156,26 @@ pub struct Param {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TopLevel {
     FnDef {
-        name: String,
+        name: FunctionName,
         params: Vec<Param>,
         return_type: Type,
         body: Expr,
         span: Span,
     },
     LetDef {
-        name: String,
+        name: VariableName,
         ty: Type,
         value: Expr,
         mutable: bool,
         span: Span,
     },
     EnumDef {
-        name: String,
-        variants: Vec<String>,
+        name: TypeName,
+        variants: Vec<VariantName>,
         span: Span,
     },
     StructDef {
-        name: String,
+        name: TypeName,
         fields: Vec<StructField>,
         span: Span,
     },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
 pub mod ast;
 
 use crate::lexer::token::{Span, Token, TokenKind};
+use crate::names::{FieldName, FunctionName, TypeName, VariableName, VariantName};
 use ast::*;
 
 /// パースエラーの種類
@@ -155,7 +156,7 @@ impl Parser {
         let return_type = self.parse_type()?;
         let body = self.parse_block_expr()?;
         Ok(TopLevel::FnDef {
-            name,
+            name: FunctionName::from(name),
             params,
             return_type,
             body,
@@ -172,7 +173,10 @@ impl Parser {
             let (name, _) = self.expect_ident()?;
             self.expect(&TokenKind::Colon)?;
             let ty = self.parse_type()?;
-            params.push(Param { name, ty });
+            params.push(Param {
+                name: VariableName::from(name),
+                ty,
+            });
             if self.peek() == &TokenKind::Comma {
                 self.advance();
             } else {
@@ -196,7 +200,7 @@ impl Parser {
         let value = self.parse_expr()?;
         self.expect(&TokenKind::Semicolon)?;
         Ok(TopLevel::LetDef {
-            name,
+            name: VariableName::from(name),
             ty,
             value,
             mutable,
@@ -212,14 +216,14 @@ impl Parser {
         let mut variants = Vec::new();
         while self.peek() != &TokenKind::RBrace {
             let (variant, _) = self.expect_ident()?;
-            variants.push(variant);
+            variants.push(VariantName::from(variant));
             if self.peek() == &TokenKind::Comma {
                 self.advance();
             }
         }
         self.expect(&TokenKind::RBrace)?;
         Ok(TopLevel::EnumDef {
-            name,
+            name: TypeName::from(name),
             variants,
             span,
         })
@@ -236,7 +240,7 @@ impl Parser {
             self.expect(&TokenKind::Colon)?;
             let ty = self.parse_type()?;
             fields.push(StructField {
-                name: field_name,
+                name: FieldName::from(field_name),
                 ty,
             });
             if self.peek() == &TokenKind::Comma {
@@ -244,7 +248,11 @@ impl Parser {
             }
         }
         self.expect(&TokenKind::RBrace)?;
-        Ok(TopLevel::StructDef { name, fields, span })
+        Ok(TopLevel::StructDef {
+            name: TypeName::from(name),
+            fields,
+            span,
+        })
     }
 
     // ---- 型 ----
@@ -263,7 +271,7 @@ impl Parser {
                         self.expect(&TokenKind::RParen)?;
                         Ok(Type::Sprite(size as usize))
                     }
-                    _ => Ok(Type::UserType(name)),
+                    _ => Ok(Type::UserType(TypeName::from(name))),
                 }
             }
             TokenKind::LParen => {
@@ -320,7 +328,11 @@ impl Parser {
                 let value = self.parse_expr()?;
                 self.expect(&TokenKind::Semicolon)?;
                 Ok(Stmt {
-                    kind: StmtKind::Let { name, ty, value },
+                    kind: StmtKind::Let {
+                        name: VariableName::from(name),
+                        ty,
+                        value,
+                    },
                     span,
                 })
             }
@@ -502,7 +514,7 @@ impl Parser {
                 expr = Expr {
                     kind: ExprKind::FieldAccess {
                         expr: Box::new(expr),
-                        field,
+                        field: FieldName::from(field),
                     },
                     span,
                 };
@@ -545,8 +557,8 @@ impl Parser {
                     let (variant, _) = self.expect_ident()?;
                     return Ok(Expr {
                         kind: ExprKind::EnumVariant {
-                            enum_name: name,
-                            variant,
+                            enum_name: TypeName::from(name),
+                            variant: VariantName::from(variant),
                         },
                         span,
                     });
@@ -575,12 +587,15 @@ impl Parser {
                     let kind = if let Some(builtin) = BuiltinFunction::from_name(&name) {
                         ExprKind::BuiltinCall { builtin, args }
                     } else {
-                        ExprKind::Call { name, args }
+                        ExprKind::Call {
+                            name: FunctionName::from(name),
+                            args,
+                        }
                     };
                     Ok(Expr { kind, span })
                 } else {
                     Ok(Expr {
-                        kind: ExprKind::Ident(name),
+                        kind: ExprKind::Ident(VariableName::from(name)),
                         span,
                     })
                 }
@@ -649,14 +664,18 @@ impl Parser {
             let (field_name, _) = self.expect_ident()?;
             self.expect(&TokenKind::Colon)?;
             let value = self.parse_expr()?;
-            fields.push((field_name, value));
+            fields.push((FieldName::from(field_name), value));
             if self.peek() == &TokenKind::Comma {
                 self.advance();
             }
         }
         self.expect(&TokenKind::RBrace)?;
         Ok(Expr {
-            kind: ExprKind::StructLiteral { name, fields, base },
+            kind: ExprKind::StructLiteral {
+                name: TypeName::from(name),
+                fields,
+                base,
+            },
             span,
         })
     }
@@ -840,7 +859,10 @@ impl Parser {
         let kind = if let Some(builtin) = BuiltinFunction::from_name(&name) {
             ExprKind::BuiltinCall { builtin, args }
         } else {
-            ExprKind::Call { name, args }
+            ExprKind::Call {
+                name: FunctionName::from(name),
+                args,
+            }
         };
         Ok(Expr { kind, span })
     }

--- a/tests/analyzer_tests.rs
+++ b/tests/analyzer_tests.rs
@@ -1,5 +1,6 @@
 use chip8_lang::analyzer::{AnalyzeError, AnalyzeErrorKind, Analyzer};
 use chip8_lang::lexer::Lexer;
+use chip8_lang::names::{FieldName, TypeName, VariableName, VariantName};
 use chip8_lang::parser::Parser;
 use chip8_lang::parser::ast::{BuiltinFunction, Type};
 
@@ -405,8 +406,8 @@ fn test_enum_undefined_variant() {
             Dir::Left
          }",
         AnalyzeErrorKind::UndefinedEnumVariant {
-            enum_name: "Dir".to_string(),
-            variant: "Left".to_string(),
+            enum_name: TypeName::from("Dir"),
+            variant: VariantName::from("Left"),
         },
     );
 }
@@ -418,7 +419,7 @@ fn test_enum_undefined_enum() {
             let x: u8 = 0;
             Foo::Bar;
          }",
-        AnalyzeErrorKind::UndefinedEnum("Foo".to_string()),
+        AnalyzeErrorKind::UndefinedEnum(TypeName::from("Foo")),
     );
 }
 
@@ -448,8 +449,8 @@ fn test_match_enum_non_exhaustive() {
             }
          }",
         AnalyzeErrorKind::NonExhaustiveMatch {
-            enum_name: "Dir".to_string(),
-            missing: vec!["Left".to_string()],
+            enum_name: TypeName::from("Dir"),
+            missing: vec![VariantName::from("Left")],
         },
     );
 }
@@ -460,7 +461,7 @@ fn test_unknown_type() {
         "fn main() -> () {
             let x: Foo = 0;
          }",
-        AnalyzeErrorKind::UnknownType("Foo".to_string()),
+        AnalyzeErrorKind::UnknownType(TypeName::from("Foo")),
     );
 }
 
@@ -488,7 +489,7 @@ fn test_random_enum_returns_enum_type() {
 fn test_random_enum_not_enum_name() {
     analyze_err_kind(
         "fn main() -> u8 { random_enum(Foo) }",
-        AnalyzeErrorKind::RandomEnumArgNotEnum("Foo".to_string()),
+        AnalyzeErrorKind::RandomEnumArgNotEnum(VariableName::from("Foo")),
     );
 }
 
@@ -530,8 +531,8 @@ fn test_struct_undefined_field() {
         "struct Pos { x: u8, y: u8 }
          fn main() -> Pos { Pos { x: 1, z: 2 } }",
         AnalyzeErrorKind::UndefinedField {
-            struct_name: "Pos".to_string(),
-            field: "z".to_string(),
+            struct_name: TypeName::from("Pos"),
+            field: FieldName::from("z"),
         },
     );
 }


### PR DESCRIPTION
## 何を実装したか

識別子の newtype (`FunctionName`, `VariableName`, `TypeName`, `FieldName`, `VariantName`) を導入し、AST・Analyzer・CodeGen 全体で `HashMap<String, ...>` のキーを型安全な newtype に置き換えた。

Closes #70

## もともとどういう実装だったか

Analyzer と CodeGen で関数名・変数名・型名・フィールド名・バリアント名がすべて `String` として扱われており、型レベルでの区別がなかった。

```rust
// Analyzer
globals: HashMap<String, Type>,
functions: HashMap<String, FnSig>,
enums: HashMap<String, Vec<String>>,

// CodeGen
fn_addrs: HashMap<String, Addr>,
data_offsets: HashMap<String, u16>,
enum_variant_values: HashMap<(String, String), u8>,
```

このため、関数名で変数用の HashMap を引いても、コンパイラが型エラーとして検出できない状態だった。また `AnalyzeErrorKind` の各バリアント (`UndefinedVariable(String)`, `UndefinedFunction(String)` 等) も同様に `String` で、エラーが何の識別子を指しているかが型から判別できなかった。

## どのように実装したか

1. **`src/names.rs` を新設**: `define_name_type!` マクロで 5 つの newtype を定義。各型に `Debug, Clone, PartialEq, Eq, Hash, Display, From<String>, From<&str>, AsRef<str>, Borrow<str>, PartialEq<str>` を実装
2. **AST (`src/parser/ast.rs`)**: 全 `String` 識別子フィールドを対応する newtype に置換
3. **Parser (`src/parser/mod.rs`)**: 各 AST ノード構築箇所で `FunctionName::from(name)` 等の変換を追加
4. **Analyzer (`src/analyzer/mod.rs`)**: `HashMap`/`HashSet` のキー型と `AnalyzeErrorKind` のフィールド型を newtype に置換
5. **CodeGen (`src/codegen/mod.rs`)**: `HashMap`/`HashSet` のキー型、内部型 (`ValueLocation`, `ForwardRefKind`, `LocalBinding`, `FunctionMeta`)、メソッドシグネチャを newtype に置換
6. **テスト (`tests/analyzer_tests.rs`)**: エラー値の構築を newtype に更新

## なぜそのように実装したか

- **5 種類に分類した理由**: Issue では 3 種類 (`FunctionName`, `VariableName`, `TypeName`) の提案だったが、struct フィールド名と enum バリアント名はそれぞれ独立した名前空間を持つため、`FieldName` と `VariantName` を追加して 5 種類とした。これにより `enum_variant_values: HashMap<(TypeName, VariantName), u8>` のように tuple key の意味が型から明確になる
- **`Borrow<str>` を実装した理由**: `HashMap<FunctionName, T>::get("main")` のように `&str` で直接検索できるようにし、lookup のたびに newtype を構築する allocation を回避するため
- **`PartialEq<str>` を実装した理由**: テストやパターンマッチで `name == "main"` のような直接比較を可能にし、`.as_str()` の頻出を抑えるため
- **マクロで定義した理由**: 5 型すべてが同一のトレイト実装を持つため、`define_name_type!` マクロでボイラープレートを共通化し、新しい識別子型の追加を容易にするため
- **AST から一括で変更した理由**: AST の型変更は Analyzer・CodeGen にカスケードするため、段階的に分離した PR にすると中間状態でコンパイルが通らない。1 コミットで全レイヤーを一貫して変更した

## Test plan

- [x] `cargo test` — 全 221 テスト通過
- [x] `cargo clippy` — 警告なし
- [x] `cargo fmt --check` — フォーマット OK


🤖 Generated with [Claude Code](https://claude.com/claude-code)